### PR TITLE
feat: add fallback to I18nProvider for client-side loading

### DIFF
--- a/examples/next/pages/_app.tsx
+++ b/examples/next/pages/_app.tsx
@@ -4,7 +4,7 @@ import { I18nProvider } from '../locales';
 
 const App = ({ Component, pageProps }: AppProps) => {
   return (
-    <I18nProvider locale={pageProps.locale}>
+    <I18nProvider locale={pageProps.locale} fallback={<p>Loading initial locale client-side</p>}>
       <Component {...pageProps} />
     </I18nProvider>
   );

--- a/examples/next/pages/index.tsx
+++ b/examples/next/pages/index.tsx
@@ -32,6 +32,7 @@ const Home = () => {
   );
 };
 
+// Comment this to disable SSR of initial locale
 export const getStaticProps: GetStaticProps = getLocaleStaticProps();
 
 export default Home;

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -2,7 +2,7 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="./assets/logo-white.png">
     <source media="(prefers-color-scheme: light)" srcset="./assets/logo-black.png" />
-    <img alt="" height="80px" src="./assets/logo-white.png">
+    <img alt="" height="100px" src="./assets/logo-white.png">
   </picture>
   <br />
   Type-safe internationalization (i18n) for Next.js
@@ -73,7 +73,7 @@ function App({ Component, pageProps }) => {
 }
 ```
 
-3. Add `getLocaleStaticProps` to your pages, or wrap your existing `getStaticProps` (this will allows SSR locales, see []):
+3. Add `getLocaleStaticProps` to your pages, or wrap your existing `getStaticProps` (this will allows SSR locales, see [Load initial locales client-side](#load-initial-locales-client-side) if you want to load the initial locale client-side):
 
 ```ts
 // pages/index.tsx
@@ -151,6 +151,8 @@ export const {
 ```
 
 ### Load initial locales client-side
+
+> **Warning**: This should not be used unless you know what you're doing and what that implies.
 
 If for x reason you don't want to SSR the initial locale, you can load it on the client. Simply remove the `getLocaleStaticProps` from your pages.
 

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -58,7 +58,22 @@ export default {
 } as const
 ```
 
-3. Add `getLocaleStaticProps` to your pages if you want SSR, or wrap your existing `getStaticProps`:
+3. Wrap your whole app with `I18nProvider` inside `_app.tsx`:
+
+```tsx
+// pages/app.tsx
+import { I18nProvider } from '../locales'
+
+function App({ Component, pageProps }) => {
+  return (
+    <I18nProvider locale={pageProps.locale}>
+      <Component {...pageProps} />
+    </I18nProvider>
+  )
+}
+```
+
+3. Add `getLocaleStaticProps` to your pages, or wrap your existing `getStaticProps` (this will allows SSR locales, see []):
 
 ```ts
 // pages/index.tsx
@@ -133,6 +148,18 @@ export const {
   en: () => import('./en.json'),
   fr: () => import('./fr.json'),
 });
+```
+
+### Load initial locales client-side
+
+If for x reason you don't want to SSR the initial locale, you can load it on the client. Simply remove the `getLocaleStaticProps` from your pages.
+
+You can also provide a fallback component while waiting for the initial locale to load inside `I18nProvider`:
+
+```tsx
+<I18nProvider locale={pageProps.locale} fallback={<p>Loading locales...</p>}>
+  ...
+</I18nProvider>
 ```
 
 ## License

--- a/packages/next-international/package.json
+++ b/packages/next-international/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-international",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Type-safe internationalization (i18n) for Next.js",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/next-international/src/i18n/create-i18n-provider.tsx
+++ b/packages/next-international/src/i18n/create-i18n-provider.tsx
@@ -1,10 +1,11 @@
-import React, { Context, ReactNode, useEffect, useState } from 'react';
+import React, { Context, ReactElement, ReactNode, useEffect, useState } from 'react';
 import { LocaleContext, Locales, Locale } from '../types';
 import { useRouter } from 'next/router';
 import { warn } from '../helpers/log';
 
 type I18nProviderProps<LocaleType extends Locale> = {
   locale: LocaleType;
+  fallback?: ReactElement;
   children: ReactNode;
 };
 
@@ -12,16 +13,8 @@ export function createI18nProvider<LocaleType extends Locale>(
   I18nContext: Context<LocaleContext<LocaleType> | null>,
   locales: Locales,
 ) {
-  return function I18nProvider({ locale: baseLocale, children }: I18nProviderProps<LocaleType>) {
-    const {
-      locale,
-      defaultLocale,
-      locales: nextLocales,
-    } = useRouter() as {
-      locale: string | undefined;
-      defaultLocale: string | undefined;
-      locales: string[] | undefined;
-    };
+  return function I18nProvider({ locale: baseLocale, fallback, children }: I18nProviderProps<LocaleType>) {
+    const { locale, defaultLocale, locales: nextLocales } = useRouter();
     const [clientLocale, setClientLocale] = useState<LocaleType>();
 
     useEffect(() => {
@@ -62,6 +55,10 @@ export function createI18nProvider<LocaleType extends Locale>(
     if (!nextLocales) {
       warn(`'i18n.locales' not defined in 'next.config.js'`);
       return null;
+    }
+
+    if (!clientLocale && !baseLocale) {
+      return fallback || null;
     }
 
     return (


### PR DESCRIPTION
Add a new `fallback` option (that is optional) to `I18nProvider`, for when you don't want to have the initial locale SSRed. 