### PR TITLE
feat: improve error messages

### DIFF
--- a/packages/next-international/src/helpers/log.ts
+++ b/packages/next-international/src/helpers/log.ts
@@ -1,5 +1,13 @@
-export function warn(message: string) {
+function log(type: keyof Pick<typeof console, 'error' | 'warn'>, message: string) {
   if (process.env.NODE_ENV !== 'production') {
-    console.warn(`[next-international] ${message}`);
+    console[type](`[next-international] ${message}`);
   }
+}
+
+export function warn(message: string) {
+  log('warn', message);
+}
+
+export function error(message: string) {
+  log('error', message);
 }

--- a/packages/next-international/src/i18n/create-get-locale-static-props.ts
+++ b/packages/next-international/src/i18n/create-get-locale-static-props.ts
@@ -1,10 +1,18 @@
 import { Locales } from '../types';
 import type { GetStaticProps } from 'next';
+import { error } from '../helpers/log';
 
 export function createGetLocaleStaticProps(locales: Locales) {
   return function getLocaleStaticProps<T>(initialGetStaticProps?: GetStaticProps<T>) {
     const getStaticProps: GetStaticProps<T> = async context => {
       const initialResult = await initialGetStaticProps?.(context);
+
+      // No current locales means that `defaultLocale` does not exists
+      if (!context.locale) {
+        error(`'i18n.defaultLocale' not defined in 'next.config.js'`);
+        return initialResult || { props: {} };
+      }
+
       const load = locales[context.locale!];
 
       return {

--- a/packages/next-international/src/i18n/create-get-locale-static-props.ts
+++ b/packages/next-international/src/i18n/create-get-locale-static-props.ts
@@ -13,7 +13,7 @@ export function createGetLocaleStaticProps(locales: Locales) {
         return initialResult || { props: {} };
       }
 
-      const load = locales[context.locale!];
+      const load = locales[context.locale];
 
       return {
         ...initialResult,

--- a/packages/next-international/src/i18n/create-i18n-provider.tsx
+++ b/packages/next-international/src/i18n/create-i18n-provider.tsx
@@ -1,7 +1,7 @@
 import React, { Context, ReactElement, ReactNode, useEffect, useState } from 'react';
 import { LocaleContext, Locales, Locale } from '../types';
 import { useRouter } from 'next/router';
-import { warn } from '../helpers/log';
+import { error, warn } from '../helpers/log';
 
 type I18nProviderProps<LocaleType extends Locale> = {
   locale: LocaleType;
@@ -48,12 +48,12 @@ export function createI18nProvider<LocaleType extends Locale>(
     }, [locale, defaultLocale]);
 
     if (!locale || !defaultLocale) {
-      warn(`'i18n.defaultLocale' not defined in 'next.config.js'`);
+      error(`'i18n.defaultLocale' not defined in 'next.config.js'`);
       return null;
     }
 
     if (!nextLocales) {
-      warn(`'i18n.locales' not defined in 'next.config.js'`);
+      error(`'i18n.locales' not defined in 'next.config.js'`);
       return null;
     }
 


### PR DESCRIPTION
Add an `error` log function for `i18n.defaultLocale` & `i18n.locales` not being defined.