### PR TITLE
feat: add scopes

### DIFF
--- a/examples/next/locales/en.ts
+++ b/examples/next/locales/en.ts
@@ -4,4 +4,8 @@ export default {
   hello: 'Hello',
   welcome: 'Hello {name}!',
   'about.you': 'Hello {name}! You have {age} yo',
+  'scope.test': 'A scope',
+  'scope.more.test': 'A scope',
+  'scope.more.param': 'A scope with {param}',
+  'scope.more.and.more.test': 'A scope',
 } as const;

--- a/examples/next/locales/fr.ts
+++ b/examples/next/locales/fr.ts
@@ -6,4 +6,8 @@ export default defineLocale({
   hello: 'Bonjour',
   welcome: 'Bonjour {name}!',
   'about.you': 'Bonjour {name}! Vous avez {age} ans',
+  'scope.test': 'Un scope',
+  'scope.more.test': 'Un scope',
+  'scope.more.param': 'Un scope avec un {param}',
+  'scope.more.and.more.test': 'Un scope',
 });

--- a/examples/next/pages/index.tsx
+++ b/examples/next/pages/index.tsx
@@ -3,8 +3,9 @@ import { GetStaticProps } from 'next';
 import { getLocaleStaticProps, useChangeLocale, useI18n } from '../locales';
 
 const Home = () => {
-  const t = useI18n();
+  const { t, scopedT } = useI18n();
   const changeLocale = useChangeLocale();
+  const t2 = scopedT('scope.more');
 
   return (
     <div>
@@ -22,6 +23,13 @@ const Home = () => {
           name: 'Doe',
         })}
       </p>
+      <p>{t2('test')}</p>
+      <p>
+        {t2('param', {
+          param: 'test',
+        })}
+      </p>
+      <p>{t2('and.more.test')}</p>
       <button type="button" onClick={() => changeLocale('en')}>
         EN
       </button>

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -131,7 +131,7 @@ t('description', { identifier })
 t('ct')
 ```
 
-And of course, the scoped key, subsequents keys and params will still be autocompleted.
+And of course, the scoped key, subsequents keys and params will still be 100% type-safe.
 
 ### Change current locale
 

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -13,6 +13,7 @@
 - [Features](#features)
 - [Usage](#usage)
 - [Examples](#examples)
+  - [Scoped translations](#scoped-translations)
   - [Change current locale](#change-current-locale)
   - [Use JSON files instead of TS for locales](#use-json-files-instead-of-ts-for-locales)
   - [Load initial locales client-side](#load-initial-locales-client-side)
@@ -21,7 +22,7 @@
 
 ## Features
 
-- **100% Type-safe**: Locales in TS or JSON, type-safe `t()`, type-safe params
+- **100% Type-safe**: Locales in TS or JSON, type-safe `t()` & `scopedT()`, type-safe params
 - **Small**: 1.2 KB gzipped (1.7 KB uncompressed), no dependencies
 - **Simple**: No webpack configuration, no CLI, just pure TypeScript
 - **SSR**: Load only the required locale, SSRed
@@ -96,7 +97,7 @@ export const getStaticProps = getLocaleStaticProps((ctx) => {
 import { useI18n } from '../locales'
 
 function App() {
-  const t = useI18n()
+  const { t } = useI18n()
   return (
     <div>
       <p>{t('hello')}</p>
@@ -107,6 +108,30 @@ function App() {
 ```
 
 ## Examples
+
+### Scoped translations
+
+When you have a lot of keys, you may notice in a file that you always use and such duplicate the same scope:
+
+```ts
+// We always repeat `pages.settings`
+t('pages.settings.title')
+t('pages.settings.description', { identifier })
+t('pages.settings.cta')
+```
+
+We can avoid this using scoped translations with the `scopedT` function from `useI18n`:
+
+```ts
+const { scopedT } = useI18n()
+const t = scopedT('pages.settings')
+
+t('title')
+t('description', { identifier })
+t('ct')
+```
+
+And of course, the scoped key, subsequents keys and params will still be autocompleted.
 
 ### Change current locale
 

--- a/packages/next-international/package.json
+++ b/packages/next-international/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-international",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Type-safe internationalization (i18n) for Next.js",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/next-international/src/i18n/create-use-i18n.ts
+++ b/packages/next-international/src/i18n/create-use-i18n.ts
@@ -1,5 +1,5 @@
 import React, { useContext, Context } from 'react';
-import { Locale, LocaleContext, LocaleKeys, LocaleValue, Params, ParamsObject } from '../types';
+import { Locale, LocaleContext, LocaleKeys, LocaleValue, Params, ParamsObject, ScopedValue, Scopes } from '../types';
 
 export function createUsei18n<LocaleType extends Locale>(I18nContext: Context<LocaleContext<LocaleType> | null>) {
   return function useI18n() {
@@ -9,24 +9,43 @@ export function createUsei18n<LocaleType extends Locale>(I18nContext: Context<Lo
       throw new Error('`useI18n` must be used inside `I18nProvider`');
     }
 
-    return function t<Key extends LocaleKeys<LocaleType>, Value extends LocaleValue = LocaleType[Key]>(
-      key: Key,
-      ...params: Params<Value>['length'] extends 0 ? [] : [ParamsObject<Value>]
-    ) {
-      const { localeContent } = context;
+    function createT<Scope extends Scopes<LocaleType> | undefined>(scope: Scope) {
+      return function t<
+        Key extends LocaleKeys<LocaleType, Scope>,
+        Value extends LocaleValue = ScopedValue<LocaleType, Scope, Key>,
+      >(key: Key, ...params: Params<Value>['length'] extends 0 ? [] : [ParamsObject<Value>]) {
+        const { localeContent } = context as LocaleContext<LocaleType>;
 
-      let value = (localeContent?.[key] || key).toString();
-      const paramObject = params[0];
+        let value;
 
-      if (!paramObject) {
+        if (scope) {
+          console.log(scope, key);
+          value = (localeContent[`${scope}.${key}`] || key).toString();
+        } else {
+          value = (localeContent[key] || key).toString();
+        }
+
+        const paramObject = params[0];
+
+        if (!paramObject) {
+          return value;
+        }
+
+        for (const [param, paramValue] of Object.entries(paramObject as Locale)) {
+          value = value.toString().replace(`{${param}}`, paramValue.toString());
+        }
+
         return value;
-      }
+      };
+    }
 
-      for (const [param, paramValue] of Object.entries(paramObject as Locale)) {
-        value = value.toString().replace(`{${param}}`, paramValue.toString());
-      }
+    function scopedT<Scope extends Scopes<LocaleType>>(scope: Scope) {
+      return createT(scope);
+    }
 
-      return value;
+    return {
+      t: createT(undefined),
+      scopedT,
     };
   };
 }


### PR DESCRIPTION
Add `scopedT` to avoid duplicating the same scopes over and over, with type safety.

```ts
const t = scopedT('pages.settings')

t('title')
t('description', { identifier })
t('ct')
```