### PR TITLE
test(international-types): add type tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-dom": "18.2.0",
     "typescript": "^4.7.4",
     "vite": "^3.0.2",
+    "vite-plugin-vitest-typescript-assert": "^1.1.4",
     "vitest": "^0.18.1"
   }
 }

--- a/packages/international-types/__tests/keys.test.ts
+++ b/packages/international-types/__tests/keys.test.ts
@@ -1,0 +1,44 @@
+import * as tsd from 'vite-plugin-vitest-typescript-assert/tsd';
+import type { LocaleKeys } from '../';
+
+describe('keys', () => {
+  it('should return the keys', () => {
+    const keys = {} as LocaleKeys<
+      {
+        hello: 'Hello';
+        'hello.world': 'Hello World';
+      },
+      undefined
+    >;
+
+    tsd.expectType<'hello' | 'hello.world'>(keys);
+  });
+
+  it('should return the keys with scope', () => {
+    const keys = {} as LocaleKeys<
+      {
+        hello: 'Hello';
+        'scope.demo': 'Nested scope';
+        'scope.another.demo': 'Another nested scope';
+      },
+      'scope'
+    >;
+
+    tsd.expectType<'demo' | 'another.demo'>(keys);
+    tsd.expectType<'demo' | 'another.demo'>(keys);
+  });
+
+  it('should return the keys with nested scope', () => {
+    const keys = {} as LocaleKeys<
+      {
+        hello: 'Hello';
+        'scope.nested.demo': 'Nested scope';
+        'scope.nested.another.demo': 'Another nested scope';
+      },
+      'scope.nested'
+    >;
+
+    tsd.expectType<'demo' | 'another.demo'>(keys);
+    tsd.expectType<'demo' | 'another.demo'>(keys);
+  });
+});

--- a/packages/international-types/__tests/keys.test.ts
+++ b/packages/international-types/__tests/keys.test.ts
@@ -3,7 +3,7 @@ import type { LocaleKeys } from '../';
 
 describe('keys', () => {
   it('should return the keys', () => {
-    const keys = {} as LocaleKeys<
+    const value = {} as LocaleKeys<
       {
         hello: 'Hello';
         'hello.world': 'Hello World';
@@ -11,11 +11,11 @@ describe('keys', () => {
       undefined
     >;
 
-    tsd.expectType<'hello' | 'hello.world'>(keys);
+    tsd.expectType<'hello' | 'hello.world'>(value);
   });
 
   it('should return the keys with scope', () => {
-    const keys = {} as LocaleKeys<
+    const value = {} as LocaleKeys<
       {
         hello: 'Hello';
         'scope.demo': 'Nested scope';
@@ -24,12 +24,11 @@ describe('keys', () => {
       'scope'
     >;
 
-    tsd.expectType<'demo' | 'another.demo'>(keys);
-    tsd.expectType<'demo' | 'another.demo'>(keys);
+    tsd.expectType<'demo' | 'another.demo'>(value);
   });
 
   it('should return the keys with nested scope', () => {
-    const keys = {} as LocaleKeys<
+    const value = {} as LocaleKeys<
       {
         hello: 'Hello';
         'scope.nested.demo': 'Nested scope';
@@ -38,7 +37,6 @@ describe('keys', () => {
       'scope.nested'
     >;
 
-    tsd.expectType<'demo' | 'another.demo'>(keys);
-    tsd.expectType<'demo' | 'another.demo'>(keys);
+    tsd.expectType<'demo' | 'another.demo'>(value);
   });
 });

--- a/packages/international-types/__tests/params.test.ts
+++ b/packages/international-types/__tests/params.test.ts
@@ -1,0 +1,16 @@
+import * as tsd from 'vite-plugin-vitest-typescript-assert/tsd';
+import type { Params } from '../dist';
+
+describe('param', () => {
+  it('should extract param', () => {
+    const value = {} as Params<'Hello {world}'>;
+
+    tsd.expectType<['world']>(value);
+  });
+
+  it('should extract multiple params', () => {
+    const value = {} as Params<'{username}: {age}'>;
+
+    tsd.expectType<['username', 'age']>(value);
+  });
+});

--- a/packages/international-types/__tests/params.test.ts
+++ b/packages/international-types/__tests/params.test.ts
@@ -1,5 +1,5 @@
 import * as tsd from 'vite-plugin-vitest-typescript-assert/tsd';
-import type { Params } from '../dist';
+import type { Params } from '../';
 
 describe('param', () => {
   it('should extract param', () => {

--- a/packages/international-types/__tests/scopes.test.ts
+++ b/packages/international-types/__tests/scopes.test.ts
@@ -3,22 +3,22 @@ import type { Scopes } from '../';
 
 describe('scopes', () => {
   it('should return the scopes', () => {
-    const keys = {} as Scopes<{
+    const value = {} as Scopes<{
       hello: 'Hello';
       'hello.world': 'Hello World';
     }>;
 
-    tsd.expectType<'hello'>(keys);
+    tsd.expectType<'hello'>(value);
   });
 
   it('should return the nested scopes', () => {
-    const keys = {} as Scopes<{
+    const value = {} as Scopes<{
       hello: 'Hello';
       'hello.world': 'Hello World';
       'scope.demo': 'Nested scope';
       'scope.another.demo': 'Another nested scope';
     }>;
 
-    tsd.expectType<'hello' | 'scope' | 'scope.another'>(keys);
+    tsd.expectType<'hello' | 'scope' | 'scope.another'>(value);
   });
 });

--- a/packages/international-types/__tests/scopes.test.ts
+++ b/packages/international-types/__tests/scopes.test.ts
@@ -1,0 +1,24 @@
+import * as tsd from 'vite-plugin-vitest-typescript-assert/tsd';
+import type { Scopes } from '../';
+
+describe('scopes', () => {
+  it('should return the scopes', () => {
+    const keys = {} as Scopes<{
+      hello: 'Hello';
+      'hello.world': 'Hello World';
+    }>;
+
+    tsd.expectType<'hello'>(keys);
+  });
+
+  it('should return the nested scopes', () => {
+    const keys = {} as Scopes<{
+      hello: 'Hello';
+      'hello.world': 'Hello World';
+      'scope.demo': 'Nested scope';
+      'scope.another.demo': 'Another nested scope';
+    }>;
+
+    tsd.expectType<'hello' | 'scope' | 'scope.another'>(keys);
+  });
+});

--- a/packages/international-types/index.ts
+++ b/packages/international-types/index.ts
@@ -16,7 +16,7 @@ export type Params<Value extends LocaleValue> = Value extends ''
 
 export type ParamsObject<Value extends LocaleValue> = Record<Params<Value>[number], LocaleValue>;
 
-export type ExtractScopes<
+type ExtractScopes<
   Value extends string,
   Prev extends string | undefined = undefined,
 > = Value extends `${infer Head}.${infer Tail}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ importers:
       react-dom: 18.2.0
       typescript: ^4.7.4
       vite: ^3.0.2
+      vite-plugin-vitest-typescript-assert: ^1.1.4
       vitest: ^0.18.1
     devDependencies:
       '@testing-library/jest-dom': 5.16.4
@@ -48,6 +49,7 @@ importers:
       react-dom: 18.2.0_react@18.2.0
       typescript: 4.7.4
       vite: 3.0.2
+      vite-plugin-vitest-typescript-assert: 1.1.4_7l6hxwasnum7dmzcrweg72dsj4
       vitest: 0.18.1_c8@7.12.0+jsdom@20.0.0
 
   examples/next:
@@ -4037,6 +4039,17 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
+  /unleashed-typescript/1.3.0_typescript@4.7.4:
+    resolution: {integrity: sha512-ORMwdtBlEQTD4Dl+HkPVfwnIG5wKBqQn72INfCHGN8dgZ3AFKwv1m7a4tL1JEGLwCUzFVH3sq/nDxPjDmvlWwg==}
+    engines: {node: '>=12', pnpm: '>=6'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      typescript: 4.7.4
+    dev: true
+
   /update-browserslist-db/1.0.5_browserslist@4.21.2:
     resolution: {integrity: sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==}
     hasBin: true
@@ -4072,6 +4085,20 @@ packages:
       '@jridgewell/trace-mapping': 0.3.14
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.8.0
+    dev: true
+
+  /vite-plugin-vitest-typescript-assert/1.1.4_7l6hxwasnum7dmzcrweg72dsj4:
+    resolution: {integrity: sha512-ZJcjNwMmYqlxtLw6esH4upjyU5cizvOn347cvgFYqvJRIR676vEe6cKZLF2WQMgKJ4sea2w2TaY3wmx9nJBynw==}
+    engines: {node: '>=12', pnpm: '>=6'}
+    peerDependencies:
+      typescript: '*'
+      vitest: '*'
+    dependencies:
+      magic-string: 0.26.2
+      micromatch: 4.0.5
+      typescript: 4.7.4
+      unleashed-typescript: 1.3.0_typescript@4.7.4
+      vitest: 0.18.1_c8@7.12.0+jsdom@20.0.0
     dev: true
 
   /vite/3.0.2:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,10 +3,11 @@
 
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import { vitestTypescriptAssertPlugin } from 'vite-plugin-vitest-typescript-assert';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), vitestTypescriptAssertPlugin()],
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
Add tests for utility types of `international-types` using `vite-plugin-vitest-typescript-assert` within Vitest.