### PR TITLE
fix: correct syntax for peer deps

### DIFF
--- a/packages/next-international/package.json
+++ b/packages/next-international/package.json
@@ -32,8 +32,8 @@
     "tsup": "^6.1.3"
   },
   "peerDependencies": {
-    "next": "12.x | 11.x",
-    "react": "18.x | 17.x"
+    "next": "^12.0.0 || ^11.0.0",
+    "react": "^18.0.0 || ^17.0.0"
   },
   "dependencies": {
     "international-types": "0.1.1"


### PR DESCRIPTION
Without this I wasn't able to install the library in an `npm` project. `pnpm` seems to be fine with the syntax either way.

The error I had before this fix

```
npm ERR! Found: next@12.2.4
npm ERR! node_modules/next
npm ERR!   next@"12.2.4" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer next@"12.x | 11.x" from next-international@0.1.1
npm ERR! node_modules/next-international
npm ERR!   next-international@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```