### PR TITLE
feat: implement react translation functions

### DIFF
--- a/examples/next/pages/index.tsx
+++ b/examples/next/pages/index.tsx
@@ -18,9 +18,22 @@ const Home = () => {
         })}
       </p>
       <p>
+        Hello (with React components):{' '}
+        {t('welcome', {
+          name: <strong>John</strong>,
+        })}
+      </p>
+      <p>
         Hello:{' '}
         {t('about.you', {
           age: '23',
+          name: 'Doe',
+        })}
+      </p>
+      <p>
+        Hello (with React components):{' '}
+        {t('about.you', {
+          age: <strong>23</strong>,
           name: 'Doe',
         })}
       </p>
@@ -28,6 +41,11 @@ const Home = () => {
       <p>
         {t2('param', {
           param: 'test',
+        })}
+      </p>
+      <p>
+        {t2('param', {
+          param: <strong>test</strong>,
         })}
       </p>
       <p>{t2('and.more.test')}</p>

--- a/examples/next/pages/ssr.tsx
+++ b/examples/next/pages/ssr.tsx
@@ -18,6 +18,12 @@ const Home = () => {
         })}
       </p>
       <p>
+        Hello (with React components):{' '}
+        {t('welcome', {
+          name: <strong>John</strong>,
+        })}
+      </p>
+      <p>
         Hello:{' '}
         {t('about.you', {
           age: '23',

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -121,6 +121,7 @@ function App() {
     <div>
       <p>{t('hello')}</p>
       <p>{t('welcome', { name: 'John' })}</p>
+      <p>{t('welcome', { name: <strong>John</strong> })}</p>
     </div>
   )
 }

--- a/packages/next-international/src/index.tsx
+++ b/packages/next-international/src/index.tsx
@@ -1,2 +1,3 @@
 export { createI18n } from './i18n/create-i18n';
+export type { ReactParamsObject } from './types';
 export type { BaseLocale, LocaleValue } from 'international-types';

--- a/packages/next-international/src/types.ts
+++ b/packages/next-international/src/types.ts
@@ -1,4 +1,4 @@
-import type { BaseLocale } from 'international-types';
+import type { BaseLocale, LocaleValue, Params } from 'international-types';
 
 export type Locales = Record<string, () => Promise<any>>;
 
@@ -6,3 +6,7 @@ export type LocaleContext<Locale extends BaseLocale> = {
   localeContent: Locale;
   fallbackLocale?: Locale;
 };
+
+export type LocaleMap<T> = Record<keyof T, React.ReactNode>;
+
+export type ReactParamsObject<Value extends LocaleValue> = Record<Params<Value>[number], React.ReactNode>;


### PR DESCRIPTION
We are through the process of adding internationalization to our application and found the existing functions (`t` and `scopedT`) to be limiting as they only allowed parameters to be strings.

This pull request implements `rt` and `scopedRT` which allow parameters to be react components like `<strong>John</strong>`

This was just quickly put together, so I'm open to changing anything!

I didn't know where to put the type `ReactParamsObject` (as `international-types` doesn't depend on React, and shouldn't - as it is more generic that way) so I put it in `create-use-i18n` - help appreciated is on where it should actually be!
