### PR TITLE
feat(next-international): use a regex to allow multiple interpolations

### DIFF
--- a/packages/next-international/__tests__/use-i18n.test.tsx
+++ b/packages/next-international/__tests__/use-i18n.test.tsx
@@ -160,6 +160,33 @@ describe('useI18n', () => {
     expect(screen.getByText("Today's weather is sunny")).toBeInTheDocument();
   });
 
+  it('should translate with the same param used twice', async () => {
+    const { useI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
+      en: () => import('./utils/en'),
+      fr: () => import('./utils/fr'),
+    });
+
+    function App() {
+      const { t } = useI18n();
+
+      return (
+        <p>
+          {t('double.param', {
+            param: '<PARAMETER>',
+          })}
+        </p>
+      );
+    }
+
+    render(
+      <I18nProvider locale={en}>
+        <App />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('This <PARAMETER> is used twice (<PARAMETER>)')).toBeInTheDocument();
+  });
+
   it('should translate with multiple params', async () => {
     const { useI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
       en: () => import('./utils/en'),

--- a/packages/next-international/__tests__/utils/en.ts
+++ b/packages/next-international/__tests__/utils/en.ts
@@ -9,4 +9,5 @@ export default {
   'namespace.subnamespace.weather': "Today's weather is {weather}",
   'namespace.subnamespace.user.description': '{name} is {years} years old',
   'only.exists.in.en': 'EN locale',
+  'double.param': 'This {param} is used twice ({param})',
 } as const;

--- a/packages/next-international/src/i18n/create-use-i18n.ts
+++ b/packages/next-international/src/i18n/create-use-i18n.ts
@@ -37,7 +37,7 @@ export function createUsei18n<Locale extends BaseLocale>(I18nContext: Context<Lo
         }
 
         for (const [param, paramValue] of Object.entries(paramObject as Locale)) {
-          value = value.toString().replace(`{${param}}`, paramValue.toString());
+          value = value.toString().replaceAll(`{${param}}`, paramValue.toString());
         }
 
         return value;

--- a/packages/next-international/src/i18n/create-use-i18n.ts
+++ b/packages/next-international/src/i18n/create-use-i18n.ts
@@ -37,7 +37,7 @@ export function createUsei18n<Locale extends BaseLocale>(I18nContext: Context<Lo
         }
 
         for (const [param, paramValue] of Object.entries(paramObject as Locale)) {
-          value = value.toString().replaceAll(`{${param}}`, paramValue.toString());
+          value = value.toString().replace(new RegExp(`{${param}}`, 'g'), paramValue.toString());
         }
 
         return value;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["ES2021.String"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     "jsx": "react",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["ES2021.String"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     "jsx": "react",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
Right now it`s not possible to use a translation text that uses the same variable more than once, because only the first instance will be interpolated