### PR TITLE
feat(international-types): support plural forms

### DIFF
--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "next": "12.2.2",
-    "next-international": "workspace:0.3.2",
+    "next-international": "workspace:0.3.3",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/packages/international-types/__tests/params.test.ts
+++ b/packages/international-types/__tests/params.test.ts
@@ -13,4 +13,10 @@ describe('param', () => {
 
     tsd.expectType<['username', 'age']>(value);
   });
+
+  it('should extract params from plural', () => {
+    const value = {} as Params<'{value, plural, =1 {{value} item left} other {{value} items left}'>;
+
+    tsd.expectType<['value']>(value);
+  });
 });

--- a/packages/international-types/index.ts
+++ b/packages/international-types/index.ts
@@ -9,13 +9,13 @@ export type LocaleKeys<
 
 export type Params<Value extends LocaleValue> = Value extends ''
   ? []
-  // Plural form (e.g `{value, plural, =1 {...} other {...}}`)
-  : Value extends `{${infer Param}, ${string}, ${string}}`
-    ? [Param]
-    // Other params (e.g `This is a {param}`)
-    : Value extends `${string}{${infer Param}}${infer Tail}`
-      ? [Param, ...Params<Tail>]
-      : [];
+  : // Plural form (e.g `{value, plural, =1 {...} other {...}}`)
+  Value extends `{${infer Param}, ${string}, ${string}}`
+  ? [Param]
+  : // Other params (e.g `This is a {param}`)
+  Value extends `${string}{${infer Param}}${infer Tail}`
+  ? [Param, ...Params<Tail>]
+  : [];
 
 export type ParamsObject<Value extends LocaleValue> = Record<Params<Value>[number], LocaleValue>;
 

--- a/packages/international-types/index.ts
+++ b/packages/international-types/index.ts
@@ -9,10 +9,13 @@ export type LocaleKeys<
 
 export type Params<Value extends LocaleValue> = Value extends ''
   ? []
-  : // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  Value extends `${infer Head}{${infer Param}}${infer Tail}`
-  ? [Param, ...Params<Tail>]
-  : [];
+  // Plural form (e.g `{value, plural, =1 {...} other {...}}`)
+  : Value extends `{${infer Param}, ${string}, ${string}}`
+    ? [Param]
+    // Other params (e.g `This is a {param}`)
+    : Value extends `${string}{${infer Param}}${infer Tail}`
+      ? [Param, ...Params<Tail>]
+      : [];
 
 export type ParamsObject<Value extends LocaleValue> = Record<Params<Value>[number], LocaleValue>;
 

--- a/packages/international-types/package.json
+++ b/packages/international-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "international-types",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Type-safe internationalization (i18n) utility types",
   "types": "dist/index.d.ts",
   "keywords": [

--- a/packages/next-international/package.json
+++ b/packages/next-international/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-international",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Type-safe internationalization (i18n) for Next.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -36,6 +36,6 @@
     "react": "^18.0.0 || ^17.0.0"
   },
   "dependencies": {
-    "international-types": "0.3.2"
+    "international-types": "0.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
       eslint: 8.19.0
       eslint-config-next: 12.2.2
       next: 12.2.2
-      next-international: workspace:0.3.2
+      next-international: workspace:0.3.3
       next-transpile-modules: ^9.0.0
       react: 18.2.0
       react-dom: 18.2.0
@@ -83,7 +83,7 @@ importers:
   packages/next-international:
     specifiers:
       '@types/react': ^18.0.15
-      international-types: 0.3.2
+      international-types: 0.3.3
       next: 12.2.2
       react: 18.2.0
       tsup: ^6.1.3


### PR DESCRIPTION
Support plural forms (e.g `{value, plural, =1 {...} other {...}}`, param should be `value`) without breaking current params extraction.