### PR TITLE
fix(next-international): don't load locale client-side if SSR/SSGed

### DIFF
--- a/examples/next/next.config.js
+++ b/examples/next/next.config.js
@@ -2,7 +2,7 @@
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
   swcMinify: true,
   i18n: {
     locales: ['en', 'fr'],

--- a/examples/next/pages/index.tsx
+++ b/examples/next/pages/index.tsx
@@ -61,6 +61,6 @@ const Home = () => {
 };
 
 // Comment this to disable SSR of initial locale
-export const getStaticProps: GetStaticProps = getLocaleProps();
+// export const getStaticProps: GetStaticProps = getLocaleProps();
 
 export default Home;


### PR DESCRIPTION
When using `getLocaleProps` with `getStaticProps` / `getServerSideProps`, the locale was still loading client-side.