### PR TITLE
feat(international-types): improve plural extraction

### DIFF
--- a/packages/international-types/__tests/params.test.ts
+++ b/packages/international-types/__tests/params.test.ts
@@ -1,34 +1,59 @@
 import * as tsd from 'vite-plugin-vitest-typescript-assert/tsd';
-import type { Params } from '../index';
+import type { LocaleValue, ParamsObject } from '../index';
 
 describe('param', () => {
   it('should extract param', () => {
-    const value = {} as Params<'Hello {world}'>;
+    const value = {} as ParamsObject<'Hello {world}'>;
 
-    tsd.expectType<['world']>(value);
+    tsd.expectType<{
+      world: LocaleValue;
+    }>(value);
   });
 
   it('should extract multiple params', () => {
-    const value = {} as Params<'{username}: {age}'>;
+    const value = {} as ParamsObject<'{username}: {age}'>;
 
-    tsd.expectType<['username', 'age']>(value);
+    tsd.expectType<{
+      username: LocaleValue;
+      age: LocaleValue;
+    }>(value);
   });
 
   it('should extract params from plural', () => {
-    const value = {} as Params<'{value, plural, =1 {1 item left} other {Many items left}}'>;
+    const value = {} as ParamsObject<'{value, plural, =1 {1 item left} other {Many items left}}'>;
 
-    tsd.expectType<['value']>(value);
+    tsd.expectType<{
+      value: LocaleValue;
+    }>(value);
   });
 
   it('should extract two params from plural', () => {
-    const value = {} as Params<'{value, plural, =1 {{items} item left} other {{items} items left}}'>;
+    const value = {} as ParamsObject<'{value, plural, =1 {{items} item left} other {{items} items left}}'>;
 
-    tsd.expectType<['value', 'items']>(value);
+    tsd.expectType<{
+      value: LocaleValue;
+      items: LocaleValue;
+    }>(value);
   });
 
   it('should extract multiple params from plural', () => {
-    const value = {} as Params<'{value, plural, =0 {{items} left} =1 {{items} item left} other {{items} items left}}'>;
+    const value =
+      {} as ParamsObject<'{value, plural, =0 {{items} left} =1 {{items} item left} other {{items} items left}}'>;
 
-    tsd.expectType<['value', 'items']>(value);
+    tsd.expectType<{
+      value: LocaleValue;
+      items: LocaleValue;
+    }>(value);
+  });
+
+  it('should extract multiple params from plural with different params', () => {
+    const value =
+      {} as ParamsObject<'{value, plural, =0 {{items} left} =1 {{items} item left} other {You have too many {custom}}}'>;
+
+    tsd.expectType<{
+      value: LocaleValue;
+      items: LocaleValue;
+      custom: LocaleValue;
+    }>(value);
   });
 });

--- a/packages/international-types/index.ts
+++ b/packages/international-types/index.ts
@@ -7,7 +7,7 @@ export type LocaleKeys<
   Key extends string = Extract<keyof Locale, string>,
 > = Scope extends undefined ? Key : Key extends `${Scope}.${infer Test}` ? Test : never;
 
-type Delimiter = '=0' | '=1' | 'other';
+type Delimiter = `=${number}` | 'other';
 
 type ExtractParam<Value extends LocaleValue> = Value extends `${string}{${infer Param}}${string}` ? Param : never;
 

--- a/packages/international-types/index.ts
+++ b/packages/international-types/index.ts
@@ -13,9 +13,11 @@ type ExtractParam<Value extends LocaleValue> = Value extends `${string}{${infer 
 
 export type Params<Value extends LocaleValue> = Value extends ''
   ? []
-  : Value extends `{${infer Param}, plural, ${Delimiter} {${infer Content}} ${Delimiter} {${infer Content2}} ${Delimiter} {${infer Content3}}}`
+  : // Plural with 3 cases
+  Value extends `{${infer Param}, plural, ${Delimiter} {${infer Content}} ${Delimiter} {${infer Content2}} ${Delimiter} {${infer Content3}}}`
   ? [Param, ExtractParam<Content>, ExtractParam<Content2>, ExtractParam<Content3>]
-  : Value extends `{${infer Param}, plural, ${Delimiter} {${infer Content}} ${Delimiter} {${infer Content2}}}`
+  : // Plural with 2 cases
+  Value extends `{${infer Param}, plural, ${Delimiter} {${infer Content}} ${Delimiter} {${infer Content2}}}`
   ? [Param, ExtractParam<Content>, ExtractParam<Content2>]
   : // Simple cases (e.g `This is a {param}`)
   Value extends `${string}{${infer Param}}${infer Tail}`

--- a/packages/international-types/index.ts
+++ b/packages/international-types/index.ts
@@ -9,29 +9,18 @@ export type LocaleKeys<
 
 type Delimiter = '=0' | '=1' | 'other';
 
-type ExtractSentence<Value extends string> =
-  Value extends `${Delimiter} {${infer Content}} ${Delimiter} ${string} ${Delimiter} ${string}`
-    ? Content
-    : Value extends `${Delimiter} {${infer Content}} ${Delimiter} ${string}`
-    ? Content
-    : never;
+type ExtractParam<Value extends LocaleValue> = Value extends `${string}{${infer Param}}${string}` ? Param : never;
 
 export type Params<Value extends LocaleValue> = Value extends ''
   ? []
-  : // Plural form (e.g `{value, plural, =1 {...} other {...}}`)
-  Value extends `{${infer Param}, ${string}, ${infer Tail}}`
-  ? [Param, ...Params<ExtractSentence<Tail>>]
-  : // Other params (e.g `This is a {param}`)
+  : Value extends `{${infer Param}, plural, ${Delimiter} {${infer Content}} ${Delimiter} {${infer Content2}} ${Delimiter} {${infer Content3}}}`
+  ? [Param, ExtractParam<Content>, ExtractParam<Content2>, ExtractParam<Content3>]
+  : Value extends `{${infer Param}, plural, ${Delimiter} {${infer Content}} ${Delimiter} {${infer Content2}}}`
+  ? [Param, ExtractParam<Content>, ExtractParam<Content2>]
+  : // Simple cases (e.g `This is a {param}`)
   Value extends `${string}{${infer Param}}${infer Tail}`
   ? [Param, ...Params<Tail>]
   : [];
-
-type a =
-  Params<'{length, plural, =0 {Please choose {label}.} =1 {{label} must have at least one character.} other {{label} must have at least # characters.}}'>;
-type b = Params<'{nbRules, plural, =1 {{nbRules} rule} other {{nbRules} rules}}'>;
-type c =
-  Params<'{nbScopes, plural, =1 {{nbScopes} scope} other {{nbScopes} scopes}}, {nbPermissionSets, plural, =1 {{nbPermissionSets} permission set} other {{nbPermissionSets} permissions sets}}'>;
-type d = Params<'{count, plural, =0 {Add a member} other {Add another member}'>;
 
 export type ParamsObject<Value extends LocaleValue> = Record<Params<Value>[number], LocaleValue>;
 

--- a/packages/international-types/package.json
+++ b/packages/international-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "international-types",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Type-safe internationalization (i18n) utility types",
   "types": "dist/index.d.ts",
   "keywords": [


### PR DESCRIPTION
Improve the params extraction to better support plural with `=0`, `=1`, `other` delimiters