### PR TITLE
feat: add use scoped i18n hook

### DIFF
--- a/examples/next/locales/index.ts
+++ b/examples/next/locales/index.ts
@@ -1,7 +1,9 @@
 import { createI18n } from 'next-international';
 import type Locale from './en';
 
-export const { useI18n, I18nProvider, useChangeLocale, defineLocale, getLocaleProps } = createI18n<typeof Locale>({
+export const { useI18n, useScopedI18n, I18nProvider, useChangeLocale, defineLocale, getLocaleProps } = createI18n<
+  typeof Locale
+>({
   en: () => import('./en'),
   fr: () => import('./fr'),
 });

--- a/examples/next/pages/index.tsx
+++ b/examples/next/pages/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { GetStaticProps } from 'next';
-import { getLocaleProps, useChangeLocale, useI18n } from '../locales';
+import { useChangeLocale, useI18n, useScopedI18n } from '../locales';
 
 const Home = () => {
-  const { t, scopedT } = useI18n();
+  const t = useI18n();
   const changeLocale = useChangeLocale();
-  const t2 = scopedT('scope.more');
+  const t2 = useScopedI18n('scope.more');
 
   return (
     <div>

--- a/examples/next/pages/ssr.tsx
+++ b/examples/next/pages/ssr.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { GetServerSideProps } from 'next';
-import { getLocaleProps, useChangeLocale, useI18n } from '../locales';
+import { getLocaleProps, useChangeLocale, useI18n, useScopedI18n } from '../locales';
 
 const Home = () => {
-  const { t, scopedT } = useI18n();
+  const t = useI18n();
   const changeLocale = useChangeLocale();
-  const t2 = scopedT('scope.more');
+  const t2 = useScopedI18n('scope.more');
 
   return (
     <div>

--- a/packages/next-international/__tests__/fallback-locale.test.tsx
+++ b/packages/next-international/__tests__/fallback-locale.test.tsx
@@ -27,7 +27,7 @@ describe('fallbackLocale', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return <p>{t('only.exists.in.en')}</p>;
     }
@@ -49,7 +49,7 @@ describe('fallbackLocale', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return <p>{t('only.exists.in.en')}</p>;
     }

--- a/packages/next-international/__tests__/i18n-provider.test.tsx
+++ b/packages/next-international/__tests__/i18n-provider.test.tsx
@@ -27,7 +27,7 @@ describe('I18nProvider', () => {
       });
 
       function App() {
-        const { t } = useI18n();
+        const t = useI18n();
 
         return <p>{t('hello')}</p>;
       }
@@ -53,7 +53,7 @@ describe('I18nProvider', () => {
       });
 
       function App() {
-        const { t } = useI18n();
+        const t = useI18n();
 
         return <p>{t('hello')}</p>;
       }
@@ -84,7 +84,7 @@ describe('I18nProvider', () => {
       });
 
       function App() {
-        const { t } = useI18n();
+        const t = useI18n();
 
         return <p>{t('hello')}</p>;
       }
@@ -109,7 +109,7 @@ describe('I18nProvider', () => {
       });
 
       function App() {
-        const { t } = useI18n();
+        const t = useI18n();
 
         return <p>{t('hello')}</p>;
       }

--- a/packages/next-international/__tests__/use-change-locale.test.tsx
+++ b/packages/next-international/__tests__/use-change-locale.test.tsx
@@ -32,7 +32,7 @@ describe('useChangeLocale', () => {
 
     function App() {
       const changeLocale = useChangeLocale();
-      const { t } = useI18n();
+      const t = useI18n();
 
       return (
         <div>

--- a/packages/next-international/__tests__/use-i18n.test.tsx
+++ b/packages/next-international/__tests__/use-i18n.test.tsx
@@ -37,7 +37,7 @@ describe('useI18n', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return <p>{t('hello')}</p>;
     }
@@ -62,7 +62,7 @@ describe('useI18n', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return <p>{t('hello')}</p>;
     }
@@ -84,7 +84,7 @@ describe('useI18n', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return <p>{t('hello')}</p>;
     }
@@ -99,7 +99,7 @@ describe('useI18n', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return <p>{t('hello')}</p>;
     }
@@ -120,7 +120,7 @@ describe('useI18n', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return <p>{t('hello.world')}</p>;
     }
@@ -141,7 +141,7 @@ describe('useI18n', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return (
         <p>
@@ -168,7 +168,7 @@ describe('useI18n', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return (
         <p data-testid="test">
@@ -194,7 +194,7 @@ describe('useI18n', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return (
         <p>
@@ -220,7 +220,7 @@ describe('useI18n', () => {
     });
 
     function App() {
-      const { t } = useI18n();
+      const t = useI18n();
 
       return (
         <p>
@@ -239,142 +239,6 @@ describe('useI18n', () => {
     );
 
     expect(screen.getByText('John is 30 years old')).toBeInTheDocument();
-  });
-
-  it('should translate with scoped', async () => {
-    const { useI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
-      en: () => import('./utils/en'),
-      fr: () => import('./utils/fr'),
-    });
-
-    function App() {
-      const { scopedT } = useI18n();
-      const t = scopedT('namespace');
-
-      return <p>{t('hello')}</p>;
-    }
-
-    render(
-      <I18nProvider locale={en}>
-        <App />
-      </I18nProvider>,
-    );
-
-    expect(screen.getByText('Hello')).toBeInTheDocument();
-  });
-
-  it('should translate multiple keys with scoped', async () => {
-    const { useI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
-      en: () => import('./utils/en'),
-      fr: () => import('./utils/fr'),
-    });
-
-    function App() {
-      const { scopedT } = useI18n();
-      const t = scopedT('namespace.subnamespace');
-
-      return (
-        <>
-          <p>{t('hello')}</p>
-          <p>{t('hello.world')}</p>
-        </>
-      );
-    }
-
-    render(
-      <I18nProvider locale={en}>
-        <App />
-      </I18nProvider>,
-    );
-
-    expect(screen.getByText('Hello')).toBeInTheDocument();
-    expect(screen.getByText('Hello World!')).toBeInTheDocument();
-  });
-
-  it('should translate with param and scoped', async () => {
-    const { useI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
-      en: () => import('./utils/en'),
-      fr: () => import('./utils/fr'),
-    });
-
-    function App() {
-      const { scopedT } = useI18n();
-      const t = scopedT('namespace.subnamespace');
-
-      return (
-        <p>
-          {t('weather', {
-            weather: 'sunny',
-          })}
-        </p>
-      );
-    }
-
-    render(
-      <I18nProvider locale={en}>
-        <App />
-      </I18nProvider>,
-    );
-
-    expect(screen.getByText("Today's weather is sunny")).toBeInTheDocument();
-  });
-
-  it('should translate with multiple params and scoped', async () => {
-    const { useI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
-      en: () => import('./utils/en'),
-      fr: () => import('./utils/fr'),
-    });
-
-    function App() {
-      const { scopedT } = useI18n();
-      const t = scopedT('namespace.subnamespace');
-
-      return (
-        <p>
-          {t('user.description', {
-            name: 'John',
-            years: '30',
-          })}
-        </p>
-      );
-    }
-
-    render(
-      <I18nProvider locale={en}>
-        <App />
-      </I18nProvider>,
-    );
-
-    expect(screen.getByText('John is 30 years old')).toBeInTheDocument();
-  });
-
-  it('should translate with multiple params and scoped (using react component)', async () => {
-    const { useI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
-      en: () => import('./utils/en'),
-      fr: () => import('./utils/fr'),
-    });
-
-    function App() {
-      const { scopedT } = useI18n();
-      const t = scopedT('namespace.subnamespace');
-
-      return (
-        <p data-testid="test">
-          {t('user.description', {
-            name: <strong>John</strong>,
-            years: '30',
-          })}
-        </p>
-      );
-    }
-
-    render(
-      <I18nProvider locale={en}>
-        <App />
-      </I18nProvider>,
-    );
-
-    expect(screen.getByTestId('test')).toHaveTextContent('John is 30 years old');
   });
 
   it('return a string if no properties are passed', async () => {
@@ -389,7 +253,7 @@ describe('useI18n', () => {
 
     const { result } = renderHook(
       () => {
-        const { t } = useI18n();
+        const t = useI18n();
         return t('hello');
       },
       {
@@ -412,7 +276,7 @@ describe('useI18n', () => {
 
     const { result } = renderHook(
       () => {
-        const { t } = useI18n();
+        const t = useI18n();
         return t('user.description', {
           name: 'John',
           years: '30',
@@ -438,7 +302,7 @@ describe('useI18n', () => {
 
     const { result } = renderHook(
       () => {
-        const { t } = useI18n();
+        const t = useI18n();
         return t('user.description', {
           name: <strong>John</strong>,
           years: '30',

--- a/packages/next-international/__tests__/use-scoped-i18n.test.tsx
+++ b/packages/next-international/__tests__/use-scoped-i18n.test.tsx
@@ -92,27 +92,6 @@ describe('useScopedI18n', () => {
   });
 
   it('should translate', async () => {
-    const { useI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
-      en: () => import('./utils/en'),
-      fr: () => import('./utils/fr'),
-    });
-
-    function App() {
-      const t = useI18n();
-
-      return <p>{t('hello')}</p>;
-    }
-
-    render(
-      <I18nProvider locale={en}>
-        <App />
-      </I18nProvider>,
-    );
-
-    expect(screen.getByText('Hello')).toBeInTheDocument();
-  });
-
-  it('should translate', async () => {
     const { useScopedI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
       en: () => import('./utils/en'),
       fr: () => import('./utils/fr'),

--- a/packages/next-international/__tests__/use-scoped-i18n.test.tsx
+++ b/packages/next-international/__tests__/use-scoped-i18n.test.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createI18n } from '../src';
+import { render, screen } from './utils';
+import en from './utils/en';
+
+beforeEach(() => {
+  vi.mock('next/router', () => ({
+    useRouter: vi
+      .fn()
+      .mockImplementationOnce(() => ({
+        locales: ['en', 'fr'],
+      }))
+      .mockImplementationOnce(() => ({
+        locale: 'en',
+        defaultLocale: 'en',
+      }))
+      .mockImplementation(() => ({
+        locale: 'en',
+        defaultLocale: 'en',
+        locales: ['en', 'fr'],
+      })),
+  }));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useScopedI18n', () => {
+  it('should log error if locale not set in next.config.js', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => null);
+    const { useScopedI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
+      en: () => import('./utils/en'),
+      fr: () => import('./utils/fr'),
+    });
+
+    function App() {
+      const t = useScopedI18n('namespace.subnamespace');
+
+      return <p>{t('hello')}</p>;
+    }
+
+    render(
+      <I18nProvider locale={en}>
+        <App />
+      </I18nProvider>,
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      "[next-international] 'i18n.defaultLocale' not defined in 'next.config.js'",
+    );
+
+    spy.mockReset();
+  });
+
+  it('should log error if locales not set in next.config.js', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => null);
+    const { useScopedI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
+      en: () => import('./utils/en'),
+      fr: () => import('./utils/fr'),
+    });
+
+    function App() {
+      const t = useScopedI18n('namespace.subnamespace');
+
+      return <p>{t('hello')}</p>;
+    }
+
+    render(
+      <I18nProvider locale={en}>
+        <App />
+      </I18nProvider>,
+    );
+    expect(console.error).toHaveBeenCalledWith("[next-international] 'i18n.locales' not defined in 'next.config.js'");
+
+    spy.mockReset();
+  });
+
+  it('should throw if not used inside I18nProvider', () => {
+    const { useScopedI18n } = createI18n<typeof import('./utils/en').default>({
+      en: () => import('./utils/en'),
+      fr: () => import('./utils/fr'),
+    });
+
+    function App() {
+      const t = useScopedI18n('namespace.subnamespace');
+
+      return <p>{t('hello')}</p>;
+    }
+
+    expect(() => render(<App />)).toThrowError('`useI18n` must be used inside `I18nProvider`');
+  });
+
+  it('should translate', async () => {
+    const { useI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
+      en: () => import('./utils/en'),
+      fr: () => import('./utils/fr'),
+    });
+
+    function App() {
+      const t = useI18n();
+
+      return <p>{t('hello')}</p>;
+    }
+
+    render(
+      <I18nProvider locale={en}>
+        <App />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('should translate', async () => {
+    const { useScopedI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
+      en: () => import('./utils/en'),
+      fr: () => import('./utils/fr'),
+    });
+
+    function App() {
+      const t = useScopedI18n('namespace');
+
+      return <p>{t('hello')}</p>;
+    }
+
+    render(
+      <I18nProvider locale={en}>
+        <App />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('should translate multiple keys', async () => {
+    const { useScopedI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
+      en: () => import('./utils/en'),
+      fr: () => import('./utils/fr'),
+    });
+
+    function App() {
+      const t = useScopedI18n('namespace.subnamespace');
+
+      return (
+        <>
+          <p>{t('hello')}</p>
+          <p>{t('hello.world')}</p>
+        </>
+      );
+    }
+
+    render(
+      <I18nProvider locale={en}>
+        <App />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Hello World!')).toBeInTheDocument();
+  });
+
+  it('should translate with param', async () => {
+    const { useScopedI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
+      en: () => import('./utils/en'),
+      fr: () => import('./utils/fr'),
+    });
+
+    function App() {
+      const t = useScopedI18n('namespace.subnamespace');
+
+      return (
+        <p>
+          {t('weather', {
+            weather: 'sunny',
+          })}
+        </p>
+      );
+    }
+
+    render(
+      <I18nProvider locale={en}>
+        <App />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("Today's weather is sunny")).toBeInTheDocument();
+  });
+
+  it('should translate with multiple params', async () => {
+    const { useScopedI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
+      en: () => import('./utils/en'),
+      fr: () => import('./utils/fr'),
+    });
+
+    function App() {
+      const t = useScopedI18n('namespace.subnamespace');
+
+      return (
+        <p>
+          {t('user.description', {
+            name: 'John',
+            years: '30',
+          })}
+        </p>
+      );
+    }
+
+    render(
+      <I18nProvider locale={en}>
+        <App />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('John is 30 years old')).toBeInTheDocument();
+  });
+
+  it('should translate with multiple params (using react component)', async () => {
+    const { useScopedI18n, I18nProvider } = createI18n<typeof import('./utils/en').default>({
+      en: () => import('./utils/en'),
+      fr: () => import('./utils/fr'),
+    });
+
+    function App() {
+      const t = useScopedI18n('namespace.subnamespace');
+
+      return (
+        <p data-testid="test">
+          {t('user.description', {
+            name: <strong>John</strong>,
+            years: '30',
+          })}
+        </p>
+      );
+    }
+
+    render(
+      <I18nProvider locale={en}>
+        <App />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByTestId('test')).toHaveTextContent('John is 30 years old');
+  });
+});

--- a/packages/next-international/src/i18n/create-i18n.ts
+++ b/packages/next-international/src/i18n/create-i18n.ts
@@ -1,4 +1,4 @@
-import React, { createContext } from 'react';
+import { createContext } from 'react';
 import type { Locales, LocaleContext } from '../types';
 import type { BaseLocale } from 'international-types';
 import { createDefineLocale } from './create-define-locale';
@@ -6,17 +6,20 @@ import { createGetLocaleProps } from './create-get-locale-static-props';
 import { createI18nProvider } from './create-i18n-provider';
 import { createUseChangeLocale } from './create-use-change-locale';
 import { createUsei18n } from './create-use-i18n';
+import { createScopedUsei18n } from './create-use-scoped-i18n';
 
 export function createI18n<Locale extends BaseLocale>(locales: Locales) {
   const I18nContext = createContext<LocaleContext<Locale> | null>(null);
   const I18nProvider = createI18nProvider(I18nContext, locales);
   const useI18n = createUsei18n(I18nContext);
+  const useScopedI18n = createScopedUsei18n(I18nContext);
   const useChangeLocale = createUseChangeLocale<typeof locales>();
   const defineLocale = createDefineLocale<Locale>();
   const getLocaleProps = createGetLocaleProps(locales);
 
   return {
     useI18n,
+    useScopedI18n,
     I18nProvider,
     useChangeLocale,
     defineLocale,

--- a/packages/next-international/src/i18n/create-t.ts
+++ b/packages/next-international/src/i18n/create-t.ts
@@ -1,0 +1,66 @@
+import { isValidElement, cloneElement, ReactNode } from 'react';
+import type {
+  BaseLocale,
+  LocaleKeys,
+  LocaleValue,
+  Params,
+  ParamsObject,
+  ScopedValue,
+  Scopes,
+} from 'international-types';
+import type { ReactParamsObject, LocaleContext, LocaleMap } from '../types';
+
+export function createT<Locale extends BaseLocale, Scope extends Scopes<Locale> | undefined>(
+  context: LocaleContext<Locale> | null,
+  scope: Scope | undefined,
+) {
+  function t<Key extends LocaleKeys<Locale, Scope>, Value extends LocaleValue = ScopedValue<Locale, Scope, Key>>(
+    key: Key,
+    ...params: Params<Value>['length'] extends 0 ? [] : [ParamsObject<Value>]
+  ): string;
+  function t<Key extends LocaleKeys<Locale, Scope>, Value extends LocaleValue = ScopedValue<Locale, Scope, Key>>(
+    key: Key,
+    ...params: Params<Value>['length'] extends 0 ? [] : [ReactParamsObject<Value>]
+  ): React.ReactNode;
+  function t<Key extends LocaleKeys<Locale, Scope>, Value extends LocaleValue = ScopedValue<Locale, Scope, Key>>(
+    key: Key,
+    ...params: Params<Value>['length'] extends 0 ? [] : [ParamsObject<Value> | ReactParamsObject<Value>]
+  ) {
+    const { localeContent, fallbackLocale } = context as LocaleContext<Locale>;
+
+    const value = (
+      (scope ? localeContent[`${scope}.${key}`] : localeContent[key]) ||
+      (scope ? fallbackLocale?.[`${scope}.${key}`] : fallbackLocale?.[key]) ||
+      key
+    )?.toString();
+    const paramObject = params[0];
+
+    if (!paramObject) {
+      return value;
+    }
+
+    let isString = true;
+
+    const result = value?.split(/({[^}]*})/).map((part, index) => {
+      const match = part.match(/{(.*)}/);
+
+      if (match) {
+        const param = match[1] as keyof Locale;
+        const paramValue = (paramObject as LocaleMap<Locale>)[param];
+
+        if (typeof paramValue !== 'string') isString = false;
+
+        return isValidElement(paramValue)
+          ? cloneElement(paramValue, { key: `${String(param)}-${index}` })
+          : (paramValue as ReactNode);
+      }
+
+      // if there's no match - it's not a variable and just a normal string
+      return part;
+    });
+
+    return isString ? result?.join('') : result;
+  }
+
+  return t;
+}

--- a/packages/next-international/src/i18n/create-use-i18n.ts
+++ b/packages/next-international/src/i18n/create-use-i18n.ts
@@ -1,6 +1,7 @@
-import React, { useContext, Context, isValidElement, cloneElement, ReactNode } from 'react';
-import type { BaseLocale, LocaleKeys, LocaleValue, Params, ParamsObject, ScopedValue } from 'international-types';
-import type { LocaleContext, ReactParamsObject, LocaleMap } from '../types';
+import { useContext, Context } from 'react';
+import type { BaseLocale } from 'international-types';
+import type { LocaleContext } from '../types';
+import { createT } from './create-t';
 
 export function createUsei18n<Locale extends BaseLocale>(I18nContext: Context<LocaleContext<Locale> | null>) {
   return function useI18n() {
@@ -10,57 +11,6 @@ export function createUsei18n<Locale extends BaseLocale>(I18nContext: Context<Lo
       throw new Error('`useI18n` must be used inside `I18nProvider`');
     }
 
-    function createT() {
-      function t<
-        Key extends LocaleKeys<Locale, undefined>,
-        Value extends LocaleValue = ScopedValue<Locale, undefined, Key>,
-      >(key: Key, ...params: Params<Value>['length'] extends 0 ? [] : [ParamsObject<Value>]): string;
-      function t<
-        Key extends LocaleKeys<Locale, undefined>,
-        Value extends LocaleValue = ScopedValue<Locale, undefined, Key>,
-      >(key: Key, ...params: Params<Value>['length'] extends 0 ? [] : [ReactParamsObject<Value>]): React.ReactNode;
-      function t<
-        Key extends LocaleKeys<Locale, undefined>,
-        Value extends LocaleValue = ScopedValue<Locale, undefined, Key>,
-      >(
-        key: Key,
-        ...params: Params<Value>['length'] extends 0 ? [] : [ParamsObject<Value> | ReactParamsObject<Value>]
-      ) {
-        const { localeContent, fallbackLocale } = context as LocaleContext<Locale>;
-
-        const value = (localeContent[key] || fallbackLocale?.[key] || key)?.toString();
-        const paramObject = params[0];
-
-        if (!paramObject) {
-          return value;
-        }
-
-        let isString = true;
-
-        const result = value?.split(/({[^}]*})/).map((part, index) => {
-          const match = part.match(/{(.*)}/);
-
-          if (match) {
-            const param = match[1] as keyof Locale;
-            const paramValue = (paramObject as LocaleMap<Locale>)[param];
-
-            if (typeof paramValue !== 'string') isString = false;
-
-            return isValidElement(paramValue)
-              ? cloneElement(paramValue, { key: `${String(param)}-${index}` })
-              : (paramValue as ReactNode);
-          }
-
-          // if there's no match - it's not a variable and just a normal string
-          return part;
-        });
-
-        return isString ? result?.join('') : result;
-      }
-
-      return t;
-    }
-
-    return createT();
+    return createT(context, undefined);
   };
 }

--- a/packages/next-international/src/i18n/create-use-scoped-i18n.ts
+++ b/packages/next-international/src/i18n/create-use-scoped-i18n.ts
@@ -1,14 +1,7 @@
-import React, { useContext, Context, isValidElement, cloneElement, ReactNode } from 'react';
-import type {
-  BaseLocale,
-  LocaleKeys,
-  LocaleValue,
-  Params,
-  ParamsObject,
-  ScopedValue,
-  Scopes,
-} from 'international-types';
-import type { LocaleContext, ReactParamsObject, LocaleMap } from '../types';
+import { useContext, Context } from 'react';
+import type { BaseLocale, Scopes } from 'international-types';
+import type { LocaleContext } from '../types';
+import { createT } from './create-t';
 
 export function createScopedUsei18n<Locale extends BaseLocale>(I18nContext: Context<LocaleContext<Locale> | null>) {
   return function useScopedI18n<Scope extends Scopes<Locale> | undefined>(scope: Scope) {
@@ -18,58 +11,6 @@ export function createScopedUsei18n<Locale extends BaseLocale>(I18nContext: Cont
       throw new Error('`useI18n` must be used inside `I18nProvider`');
     }
 
-    function createT() {
-      function t<Key extends LocaleKeys<Locale, Scope>, Value extends LocaleValue = ScopedValue<Locale, Scope, Key>>(
-        key: Key,
-        ...params: Params<Value>['length'] extends 0 ? [] : [ParamsObject<Value>]
-      ): string;
-      function t<Key extends LocaleKeys<Locale, Scope>, Value extends LocaleValue = ScopedValue<Locale, Scope, Key>>(
-        key: Key,
-        ...params: Params<Value>['length'] extends 0 ? [] : [ReactParamsObject<Value>]
-      ): React.ReactNode;
-      function t<Key extends LocaleKeys<Locale, Scope>, Value extends LocaleValue = ScopedValue<Locale, Scope, Key>>(
-        key: Key,
-        ...params: Params<Value>['length'] extends 0 ? [] : [ParamsObject<Value> | ReactParamsObject<Value>]
-      ) {
-        const { localeContent, fallbackLocale } = context as LocaleContext<Locale>;
-
-        const value = (
-          (scope ? localeContent[`${scope}.${key}`] : localeContent[key]) ||
-          (scope ? fallbackLocale?.[`${scope}.${key}`] : fallbackLocale?.[key]) ||
-          key
-        )?.toString();
-        const paramObject = params[0];
-
-        if (!paramObject) {
-          return value;
-        }
-
-        let isString = true;
-
-        const result = value?.split(/({[^}]*})/).map((part, index) => {
-          const match = part.match(/{(.*)}/);
-
-          if (match) {
-            const param = match[1] as keyof Locale;
-            const paramValue = (paramObject as LocaleMap<Locale>)[param];
-
-            if (typeof paramValue !== 'string') isString = false;
-
-            return isValidElement(paramValue)
-              ? cloneElement(paramValue, { key: `${String(param)}-${index}` })
-              : (paramValue as ReactNode);
-          }
-
-          // if there's no match - it's not a variable and just a normal string
-          return part;
-        });
-
-        return isString ? result?.join('') : result;
-      }
-
-      return t;
-    }
-
-    return createT();
+    return createT(context, scope);
   };
 }


### PR DESCRIPTION
This PR implements the first suggestion of #27:

> 1. `useI18n` only returns a non-scoped `t` function, we introduce a new `useScopedI18n` hook that takes the scope in parameters, similar to the current `scopedT`:
> 
> ```ts
> const t = useI18n() // non-scoped t
> const t = useScopedI18n("scope") // scoped t
> ```