### PR TITLE
fix(app-router): typesafe `getCurrentLocale` in Server Components

### DIFF
--- a/packages/next-international/src/app/server/create-get-current-locale.ts
+++ b/packages/next-international/src/app/server/create-get-current-locale.ts
@@ -1,7 +1,7 @@
 import { getCurrentLocale as getCurrentLocaleFromCache } from './create-i18n-provider-server';
 
-export function createGetCurrentLocale() {
+export function createGetCurrentLocale<LocalesKeys>(): () => LocalesKeys {
   return function getCurrentLocale() {
-    return getCurrentLocaleFromCache();
+    return getCurrentLocaleFromCache() as LocalesKeys;
   };
 }

--- a/packages/next-international/src/app/server/index.ts
+++ b/packages/next-international/src/app/server/index.ts
@@ -11,11 +11,12 @@ export function createI18nServer<Locales extends ImportedLocales, OtherLocales e
   locales: Locales,
 ) {
   type Locale = OtherLocales extends ExplicitLocales ? GetLocaleType<OtherLocales> : GetLocaleType<Locales>;
+  type LocalesKeys = OtherLocales extends ExplicitLocales ? keyof OtherLocales : keyof Locales;
 
   const I18nProviderServer = createI18nProviderServer();
   const getI18n = createGetI18n<Locale>(locales);
   const getScopedI18n = createGetScopedI18n<Locales, Locale>(locales);
-  const getCurrentLocale = createGetCurrentLocale();
+  const getCurrentLocale = createGetCurrentLocale<LocalesKeys>();
   const getStaticParams = createGetStaticParams(locales);
 
   return {


### PR DESCRIPTION
Return a correctly typed union of the locales when using `getCurrentLocale` in Server Components (similar to the current behavior with `useCurrentLocale` in pages router and client components of the app router)