### PR TITLE
feat: nested object scopes

### DIFF
--- a/examples/next-pages/locales/en.ts
+++ b/examples/next-pages/locales/en.ts
@@ -1,12 +1,39 @@
 console.log('Loaded EN');
 
+// export default {
+//   hello: 'Hello',
+//   welcome: 'Hello {name}!',
+//   'about.you': 'Hello {name}! You have {age} yo',
+//   'scope.test': 'A scope',
+//   'scope.more.test': 'A scope',
+//   'scope.more.param': 'A scope with {param}',
+//   'scope.more.and.more.test': 'A scope',
+//   'missing.translation.in.fr': 'This should work',
+// } as const;
+
 export default {
   hello: 'Hello',
   welcome: 'Hello {name}!',
-  'about.you': 'Hello {name}! You have {age} yo',
-  'scope.test': 'A scope',
-  'scope.more.test': 'A scope',
-  'scope.more.param': 'A scope with {param}',
-  'scope.more.and.more.test': 'A scope',
-  'missing.translation.in.fr': 'This should work',
+  about: {
+    you: 'Hello {name}! You have {age} yo',
+  },
+  scope: {
+    test: 'A scope',
+    more: {
+      test: 'A scope',
+      param: 'A scope with {param}',
+      and: {
+        more: {
+          test: 'A scope',
+        },
+      },
+    },
+  },
+  missing: {
+    translation: {
+      in: {
+        fr: 'This should work',
+      },
+    },
+  },
 } as const;

--- a/examples/next-pages/locales/en.ts
+++ b/examples/next-pages/locales/en.ts
@@ -1,39 +1,40 @@
 console.log('Loaded EN');
 
-// export default {
-//   hello: 'Hello',
-//   welcome: 'Hello {name}!',
-//   'about.you': 'Hello {name}! You have {age} yo',
-//   'scope.test': 'A scope',
-//   'scope.more.test': 'A scope',
-//   'scope.more.param': 'A scope with {param}',
-//   'scope.more.and.more.test': 'A scope',
-//   'missing.translation.in.fr': 'This should work',
-// } as const;
-
 export default {
   hello: 'Hello',
   welcome: 'Hello {name}!',
-  about: {
-    you: 'Hello {name}! You have {age} yo',
-  },
-  scope: {
-    test: 'A scope',
-    more: {
-      test: 'A scope',
-      param: 'A scope with {param}',
-      and: {
-        more: {
-          test: 'A scope',
-        },
-      },
-    },
-  },
-  missing: {
-    translation: {
-      in: {
-        fr: 'This should work',
-      },
-    },
-  },
+  'about.you': 'Hello {name}! You have {age} yo',
+  'scope.test': 'A scope',
+  'scope.more.test': 'A scope',
+  'scope.more.param': 'A scope with {param}',
+  'scope.more.and.more.test': 'A scope',
+  'missing.translation.in.fr': 'This should work',
 } as const;
+
+// We can also write locales using nested objects
+// export default {
+//   hello: 'Hello',
+//   welcome: 'Hello {name}!',
+//   about: {
+//     you: 'Hello {name}! You have {age} yo',
+//   },
+//   scope: {
+//     test: 'A scope',
+//     more: {
+//       test: 'A scope',
+//       param: 'A scope with {param}',
+//       and: {
+//         more: {
+//           test: 'A scope',
+//         },
+//       },
+//     },
+//   },
+//   missing: {
+//     translation: {
+//       in: {
+//         fr: 'This should work',
+//       },
+//     },
+//   },
+// } as const;

--- a/packages/international-types/index.ts
+++ b/packages/international-types/index.ts
@@ -68,3 +68,29 @@ type SomeKey<T extends Record<string, any>> = UnionToTuple<keyof T>[0] extends s
 export type GetLocaleType<Locales extends ImportedLocales | ExplicitLocales> = Locales extends ImportedLocales
   ? Awaited<ReturnType<Locales[SomeKey<Locales>]>>['default']
   : Locales[SomeKey<Locales>];
+
+type Join<K, P> = K extends string | number
+  ? P extends string | number
+    ? `${K}${'' extends P ? '' : '.'}${P}`
+    : never
+  : never;
+
+type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...0[]];
+
+type Leaves<T, D extends number = 10> = [D] extends [never]
+  ? never
+  : T extends object
+  ? { [K in keyof T]-?: Join<K, Leaves<T[K], Prev[D]>> }[keyof T]
+  : '';
+
+type FollowPath<T, P> = P extends `${infer U}.${infer R}`
+  ? U extends keyof T
+    ? FollowPath<T[U], R>
+    : never
+  : P extends keyof T
+  ? T[P]
+  : never;
+
+export type FlattenLocale<Locale extends Record<string, unknown>> = {
+  [K in Leaves<Locale>]: FollowPath<Locale, K>;
+};

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -16,6 +16,7 @@
   - [App Router](#app-router)
 - [Examples](#examples)
   - [Scoped translations](#scoped-translations)
+  - [Nested objects locales](#nested-objects-locales)
   - [Change and get current locale](#change-and-get-current-locale)
   - [Fallback locale for missing translations](#fallback-locale-for-missing-translations)
   - [Load initial locales client-side](#load-initial-locales-client-side)
@@ -373,6 +374,33 @@ export default async function Page() {
 ```
 
 </details>
+
+### Nested objects locales
+
+You can write locales using nested objects instead of the default dot notation. You can use the syntax you prefer without updating anything else:
+
+```ts
+// locales/en.ts
+export default {
+  hello: 'Hello',
+  hello: {
+    world: 'Hello world!',
+    nested: {
+      translations: 'Translations'
+    }
+  }
+} as const
+```
+
+It's the equivalent of the following:
+
+```ts
+export default {
+  'hello': 'Hello',
+  'hello.world': 'Hello world!',
+  'hello.nested.translations': 'Translations'
+} as const
+```
 
 ### Change and get the current locale
 

--- a/packages/next-international/src/pages/create-i18n-provider.tsx
+++ b/packages/next-international/src/pages/create-i18n-provider.tsx
@@ -11,6 +11,17 @@ type I18nProviderProps<Locale extends BaseLocale> = {
   children: ReactNode;
 };
 
+const flatten = <Locale extends BaseLocale>(locale: Locale, prefix = ''): Locale =>
+  Object.entries(locale).reduce(
+    (prev, [name, value]) => ({
+      ...prev,
+      ...(typeof value === 'string'
+        ? { [prefix + name]: value }
+        : flatten(value as unknown as Locale, `${prefix}${name}.`)),
+    }),
+    {} as Locale,
+  );
+
 export function createI18nProvider<Locale extends BaseLocale>(
   I18nContext: Context<LocaleContext<Locale> | null>,
   locales: ImportedLocales,
@@ -45,7 +56,7 @@ export function createI18nProvider<Locale extends BaseLocale>(
 
     const loadLocale = useCallback((locale: string) => {
       locales[locale]().then(content => {
-        setClientLocale(content.default as Locale);
+        setClientLocale(flatten(content.default));
       });
     }, []);
 

--- a/packages/next-international/src/pages/index.ts
+++ b/packages/next-international/src/pages/index.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { ImportedLocales, ExplicitLocales, GetLocaleType } from 'international-types';
+import { ImportedLocales, ExplicitLocales, GetLocaleType, FlattenLocale } from 'international-types';
 import type { LocaleContext } from '../types';
 import { createDefineLocale } from '../common/create-define-locale';
 import { createGetLocaleProps } from './create-get-locale-props';
@@ -12,7 +12,11 @@ import { createUseCurrentLocale } from './create-use-current-locale';
 export function createI18n<Locales extends ImportedLocales, OtherLocales extends ExplicitLocales | null = null>(
   locales: Locales,
 ) {
-  type Locale = OtherLocales extends ExplicitLocales ? GetLocaleType<OtherLocales> : GetLocaleType<Locales>;
+  // type Locale = OtherLocales extends ExplicitLocales ? GetLocaleType<OtherLocales> : GetLocaleType<Locales>;
+
+  type TempLocale = OtherLocales extends ExplicitLocales ? GetLocaleType<OtherLocales> : GetLocaleType<Locales>;
+  type Locale = TempLocale[keyof TempLocale] extends {} ? FlattenLocale<TempLocale> : TempLocale;
+
   type LocalesKeys = OtherLocales extends ExplicitLocales ? keyof OtherLocales : keyof Locales;
 
   const I18nContext = createContext<LocaleContext<Locale> | null>(null);

--- a/packages/next-international/src/pages/index.ts
+++ b/packages/next-international/src/pages/index.ts
@@ -12,13 +12,12 @@ import { createUseCurrentLocale } from './create-use-current-locale';
 export function createI18n<Locales extends ImportedLocales, OtherLocales extends ExplicitLocales | null = null>(
   locales: Locales,
 ) {
-  // type Locale = OtherLocales extends ExplicitLocales ? GetLocaleType<OtherLocales> : GetLocaleType<Locales>;
-
   type TempLocale = OtherLocales extends ExplicitLocales ? GetLocaleType<OtherLocales> : GetLocaleType<Locales>;
-  type Locale = TempLocale[keyof TempLocale] extends {} ? FlattenLocale<TempLocale> : TempLocale;
+  type Locale = TempLocale extends Record<string, string> ? TempLocale : FlattenLocale<TempLocale>;
 
   type LocalesKeys = OtherLocales extends ExplicitLocales ? keyof OtherLocales : keyof Locales;
 
+  // @ts-expect-error deep type
   const I18nContext = createContext<LocaleContext<Locale> | null>(null);
   const I18nProvider = createI18nProvider(I18nContext, locales);
   const useI18n = createUsei18n(I18nContext);


### PR DESCRIPTION
Closes #19 

The current syntax for writing locale is:

```ts
export default {
  hello: 'Hello',
  welcome: 'Hello {name}!',
  'about.you': 'Hello {name}! You have {age} yo',
  'scope.test': 'A scope',
  'scope.more.test': 'A scope',
  'scope.more.param': 'A scope with {param}',
  'scope.more.and.more.test': 'A scope',
  'missing.translation.in.fr': 'This should work',
} as const
```

And you're now able to write locales using nested objects:
```ts
export default {
  hello: 'Hello',
  welcome: 'Hello {name}!',
  about: {
    you: 'Hello {name}! You have {age} yo',
  },
  scope: {
    test: 'A scope',
    more: {
      test: 'A scope',
      param: 'A scope with {param}',
      and: {
        more: {
          test: 'A scope',
        },
      },
    },
  },
  missing: {
    translation: {
      in: {
        fr: 'This should work',
      },
    },
  },
} as const
```