### PR TITLE
fix(next-international): nested objects locales in App Router

### DIFF
--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -1,6 +1,7 @@
 import React, { Context, ReactElement, ReactNode, useCallback, useEffect, useState } from 'react';
 import type { LocaleContext } from '../../types';
 import type { BaseLocale, ImportedLocales } from 'international-types';
+import { flattenLocale } from '../../common/flatten-locale';
 
 type I18nProviderProps<Locale extends BaseLocale> = {
   locale: string;
@@ -23,7 +24,7 @@ export function createI18nProviderClient<Locale extends BaseLocale>(
 
     const loadLocale = useCallback((locale: string) => {
       locales[locale]().then(content => {
-        setClientLocale(content.default as Locale);
+        setClientLocale(flattenLocale(content.default));
       });
     }, []);
 

--- a/packages/next-international/src/app/server/create-get-i18n.ts
+++ b/packages/next-international/src/app/server/create-get-i18n.ts
@@ -2,6 +2,7 @@ import type { BaseLocale, ImportedLocales } from 'international-types';
 import { createT } from '../../common/create-t';
 import { LocaleContext } from '../../types';
 import { getLocaleCache } from './get-locale-cache';
+import { flattenLocale } from '../../common/flatten-locale';
 
 export function createGetI18n<Locale extends BaseLocale>(locales: ImportedLocales) {
   return async function getI18n() {
@@ -9,7 +10,7 @@ export function createGetI18n<Locale extends BaseLocale>(locales: ImportedLocale
 
     return createT(
       {
-        localeContent: (await locales[locale]()).default,
+        localeContent: flattenLocale((await locales[locale]()).default),
         fallbackLocale: undefined,
       } as LocaleContext<Locale>,
       undefined,

--- a/packages/next-international/src/app/server/create-get-scoped-i18n.ts
+++ b/packages/next-international/src/app/server/create-get-scoped-i18n.ts
@@ -2,6 +2,7 @@ import type { BaseLocale, ImportedLocales, Scopes } from 'international-types';
 import { createT } from '../../common/create-t';
 import { LocaleContext } from '../../types';
 import { getLocaleCache } from './get-locale-cache';
+import { flattenLocale } from '../../common/flatten-locale';
 
 export function createGetScopedI18n<Locales extends ImportedLocales, Locale extends BaseLocale>(locales: Locales) {
   return async function getScopedI18n<Scope extends Scopes<Locale>>(scope: Scope) {
@@ -9,7 +10,7 @@ export function createGetScopedI18n<Locales extends ImportedLocales, Locale exte
 
     return createT(
       {
-        localeContent: (await locales[locale]()).default,
+        localeContent: flattenLocale((await locales[locale]()).default),
         fallbackLocale: undefined,
       } as LocaleContext<Locale>,
       scope,

--- a/packages/next-international/src/common/flatten-locale.ts
+++ b/packages/next-international/src/common/flatten-locale.ts
@@ -1,0 +1,12 @@
+import { BaseLocale } from 'international-types';
+
+export const flattenLocale = <Locale extends BaseLocale>(locale: Locale, prefix = ''): Locale =>
+  Object.entries(locale).reduce(
+    (prev, [name, value]) => ({
+      ...prev,
+      ...(typeof value === 'string'
+        ? { [prefix + name]: value }
+        : flattenLocale(value as unknown as Locale, `${prefix}${name}.`)),
+    }),
+    {} as Locale,
+  );

--- a/packages/next-international/src/pages/create-i18n-provider.tsx
+++ b/packages/next-international/src/pages/create-i18n-provider.tsx
@@ -3,6 +3,7 @@ import type { LocaleContext } from '../types';
 import type { BaseLocale, ImportedLocales } from 'international-types';
 import { useRouter } from 'next/router';
 import { error, warn } from '../helpers/log';
+import { flattenLocale } from '../common/flatten-locale';
 
 type I18nProviderProps<Locale extends BaseLocale> = {
   locale: Locale;
@@ -10,17 +11,6 @@ type I18nProviderProps<Locale extends BaseLocale> = {
   fallbackLocale?: Locale;
   children: ReactNode;
 };
-
-const flatten = <Locale extends BaseLocale>(locale: Locale, prefix = ''): Locale =>
-  Object.entries(locale).reduce(
-    (prev, [name, value]) => ({
-      ...prev,
-      ...(typeof value === 'string'
-        ? { [prefix + name]: value }
-        : flatten(value as unknown as Locale, `${prefix}${name}.`)),
-    }),
-    {} as Locale,
-  );
 
 export function createI18nProvider<Locale extends BaseLocale>(
   I18nContext: Context<LocaleContext<Locale> | null>,
@@ -56,7 +46,7 @@ export function createI18nProvider<Locale extends BaseLocale>(
 
     const loadLocale = useCallback((locale: string) => {
       locales[locale]().then(content => {
-        setClientLocale(flatten(content.default));
+        setClientLocale(flattenLocale(content.default));
       });
     }, []);
 


### PR DESCRIPTION
Closes https://github.com/QuiiBz/next-international/issues/67

`flatten` was implemented for the Pages Router, but not for the App Router.