### PR TITLE
chore: fix docs

### DIFF
--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -384,7 +384,6 @@ You can write locales using nested objects instead of the default dot notation. 
 ```ts
 // locales/en.ts
 export default {
-  hello: 'Hello',
   hello: {
     world: 'Hello world!',
     nested: {
@@ -398,13 +397,12 @@ It's the equivalent of the following:
 
 ```ts
 export default {
-  'hello': 'Hello',
   'hello.world': 'Hello world!',
   'hello.nested.translations': 'Translations'
 } as const
 ```
 
-### Change and get the current locale
+### Change and get current locale
 
 <details>
 <summary>Pages Router</summary>


### PR DESCRIPTION
This fixes two issues in the documentation.

1. specifying the `hello` key with a string value and then also specifying it again with an object value leads to errors (at least in TS) and should not be in the example.
![image](https://github.com/QuiiBz/next-international/assets/6306291/b29f494a-4ac1-4540-ab31-b1a6baf0c66a)
```An object literal cannot have multiple properties with the same name.```

2. The direct link to `Change and get the current locale` didn't work as the heading and link mismatched. I removed the article to match the links up top.