### PR TITLE
feat: typesafe plural `count`

### DIFF
--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -392,7 +392,13 @@ export default {
 } as const
 ```
 
-The correct translation will then be determined automatically using a mandatory `count` parameter. This works with the Pages Router, App Router in both Client and Server Components, and with [scoped translations](#scoped-translations):
+The correct translation will then be determined automatically using a mandatory `count` parameter. The value of `count `is determined by the union of all suffixes, enabling type safety:
+- `zero` only allows `0`
+- `one` only allows `1`
+- `two` only allows `2`
+- `few`, `many` and `other` allow `number`
+
+This works with the Pages Router, App Router in both Client and Server Components, and with [scoped translations](#scoped-translations):
 
 ```tsx
 export default function Page() {

--- a/packages/next-international/src/common/create-t.ts
+++ b/packages/next-international/src/common/create-t.ts
@@ -36,16 +36,23 @@ export function createT<Locale extends BaseLocale, Scope extends Scopes<Locale> 
     ...params: CreateParams<ParamsObject<Value> | ReactParamsObject<Value>, Locale, Scope, Key, Value>
   ) {
     const paramObject = params[0];
+    let isPlural = false;
 
     if (paramObject && 'count' in paramObject && pluralKeys.has(key)) {
       key = `${key}#${pluralRules.select(paramObject.count)}` as Key;
+      isPlural = true;
     }
 
-    const value = (
+    let value =
       (scope ? localeContent[`${scope}.${key}`] : localeContent[key]) ||
-      (scope ? fallbackLocale?.[`${scope}.${key}`] : fallbackLocale?.[key]) ||
-      key
-    )?.toString();
+      (scope ? fallbackLocale?.[`${scope}.${key}`] : fallbackLocale?.[key]);
+
+    if (!value && isPlural) {
+      const baseKey = key.split('#')[0] as Key;
+      value = (localeContent[`${baseKey}#other`] || fallbackLocale?.[`${baseKey}#other`] || key)?.toString();
+    } else {
+      value = (value || key)?.toString();
+    }
 
     if (!paramObject) {
       return value;


### PR DESCRIPTION
Relates to #44
Following #75 

Enable type safety on the `count` params of plural translations.