### PR TITLE
fix(international-types): plural tags

### DIFF
--- a/packages/international-types/index.ts
+++ b/packages/international-types/index.ts
@@ -124,12 +124,50 @@ type GetCountUnion<
   Key extends string,
   Locale extends BaseLocale,
   Plural extends PluralSuffix = GetPlural<Key, Locale>,
-> = Plural extends 'zero' ? 0 : Plural extends 'one' ? 1 : Plural extends 'two' ? 2 : number;
+> = Plural extends 'zero'
+  ? 0
+  : Plural extends 'one'
+  ? // eslint-disable-next-line @typescript-eslint/ban-types
+    1 | 21 | 31 | 41 | 51 | 61 | 71 | 81 | 91 | 101 | (number & {})
+  : Plural extends 'two'
+  ? // eslint-disable-next-line @typescript-eslint/ban-types
+    2 | 22 | 32 | 42 | 52 | 62 | 72 | 82 | 92 | 102 | (number & {})
+  : number;
 
 type AddCount<T, Key extends string, Locale extends BaseLocale> = T extends []
-  ? [{ count: GetCountUnion<Key, Locale> }]
+  ? [
+      {
+        /**
+         * The `count` depends on the plural tags defined in your locale,
+         * and the current locale rules.
+         *
+         * - `zero` allows 0
+         * - `one` autocompletes 1, 21, 31, 41... but allows any number
+         * - `two` autocompletes 2, 22, 32, 42... but allows any number
+         * - `few`, `many` and `other` allow any number
+         *
+         * @see https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html
+         */
+        count: GetCountUnion<Key, Locale>;
+      },
+    ]
   : T extends [infer R]
-  ? [{ count: GetCountUnion<Key, Locale> } & R]
+  ? [
+      {
+        /**
+         * The `count` depends on the plural tags defined in your locale,
+         * and the current locale rules.
+         *
+         * - `zero` allows 0
+         * - `one` autocompletes 1, 21, 31, 41... but allows any number
+         * - `two` autocompletes 2, 22, 32, 42... but allows any number
+         * - `few`, `many` and `other` allow any number
+         *
+         * @see https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html
+         */
+        count: GetCountUnion<Key, Locale>;
+      } & R,
+    ]
   : never;
 
 export type CreateParams<

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -393,10 +393,11 @@ export default {
 ```
 
 The correct translation will then be determined automatically using a mandatory `count` parameter. The value of `count` is determined by the union of all suffixes, enabling type safety:
-- `zero` only allows `0`
-- `one` only allows `1`
-- `two` only allows `2`
-- `few`, `many` and `other` allow `number`
+
+- `zero` allows 0
+- `one` autocompletes 1, 21, 31, 41... but allows any number
+- `two` autocompletes 2, 22, 32, 42... but allows any number
+- `few`, `many` and `other` allow any number
 
 This works with the Pages Router, App Router in both Client and Server Components, and with [scoped translations](#scoped-translations):
 


### PR DESCRIPTION
Fix the allowed `count` values for plural tags to match the spec:

- `zero` allows 0
- `one` autocompletes 1, 21, 31, 41... but allows any number
- `two` autocompletes 2, 22, 32, 42... but allows any number
- `few`, `many` and `other` allow any number

See https://cldr.unicode.org/index/cldr-spec/plural-rules, https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html