### PR TITLE
feat(next-international): `useParams` & `rewrite` strategy to hide locale from URL

### DIFF
--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -584,13 +584,9 @@ Navigate to the `middleware.ts` file and set the `urlMappingStrategy` to `rewrit
 
 ```ts
 // middleware.ts
-// ...
-
 const I18nMiddleware = createI18nMiddleware(['en', 'fr'] as const, 'fr', {
     urlMappingStrategy: 'rewrite'
 })
-
-// ...
 ```
 
 ### Use the types for my own library

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -578,7 +578,7 @@ You can also provide a fallback component while waiting for the initial locale t
 
 ### Rewrite the URL to hide the locale
 
-You might have noticed that by default, next-international shows the locale in the URL (e.g `/en/products`). This is helpful for users, but you can transparently rewrite the URL to hide the locale (e.g `/products`).
+You might have noticed that by default, next-international redirects and shows the locale in the URL (e.g `/en/products`). This is helpful for users, but you can transparently rewrite the URL to hide the locale (e.g `/products`).
 
 Navigate to the `middleware.ts` file and set the `urlMappingStrategy` to `rewrite` (the default is `redirect`):
 

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -21,6 +21,7 @@
   - [Change and get current locale](#change-and-get-current-locale)
   - [Fallback locale for missing translations](#fallback-locale-for-missing-translations)
   - [Load initial locales client-side](#load-initial-locales-client-side)
+  - [Rewrite the URL to hide the locale](#rewrite-the-url-to-hide-the-locale)
   - [Use the types for my own library](#use-the-types-for-my-own-library)
   - [Testing](#testing)
 - [License](#license)
@@ -208,7 +209,7 @@ import { ..., getStaticParams } from '../../locales/server'
 export const generateStaticParams = getStaticParams()
 ```
 
-4. Add a `middleware.ts` file at the root of your app, that will redirect the user to the right locale:
+4. Add a `middleware.ts` file at the root of your app, that will redirect the user to the right locale. You can also [rewrite the URL to hide the locale](#rewrite-the-url-to-hide-the-locale):
 
 ```ts
 // middleware.ts
@@ -573,6 +574,23 @@ You can also provide a fallback component while waiting for the initial locale t
 <I18nProvider locale={pageProps.locale} fallback={<p>Loading locales...</p>}>
   ...
 </I18nProvider>
+```
+
+### Rewrite the URL to hide the locale
+
+You might have noticed that by default, next-international shows the locale in the URL (e.g `/en/products`). This is helpful for users, but you can transparently rewrite the URL to hide the locale (e.g `/products`).
+
+Navigate to the `middleware.ts` file and set the `urlMappingStrategy` to `rewrite` (the default is `redirect`):
+
+```ts
+// middleware.ts
+// ...
+
+const I18nMiddleware = createI18nMiddleware(['en', 'fr'] as const, 'fr', {
+    urlMappingStrategy: 'rewrite'
+})
+
+// ...
 ```
 
 ### Use the types for my own library

--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -1,5 +1,5 @@
 import React, { Context, ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import type { LocaleContext } from '../../types';
+import type { I18nConfig, LocaleContext } from '../../types';
 import type { BaseLocale, ImportedLocales } from 'international-types';
 import { flattenLocale } from '../../common/flatten-locale';
 
@@ -7,21 +7,23 @@ type I18nProviderProps = {
   locale: string;
   fallback?: ReactElement | null;
   fallbackLocale?: Record<string, unknown>;
+  config?: I18nConfig;
   children: ReactNode;
 };
 
 export function createI18nProviderClient<Locale extends BaseLocale, LocalesKeys>(
   I18nClientContext: Context<LocaleContext<Locale> | null>,
   locales: ImportedLocales,
-  useCurrentLocale: () => LocalesKeys,
+  useCurrentLocale: (config?: I18nConfig) => LocalesKeys,
 ) {
   return function I18nProviderClient({
     locale: baseLocale,
     fallback = null,
     fallbackLocale,
     children,
+    config,
   }: I18nProviderProps) {
-    const locale = useCurrentLocale();
+    const locale = useCurrentLocale(config);
     const [clientLocale, setClientLocale] = useState<Locale>();
 
     const loadLocale = useCallback((locale: string) => {

--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -1,20 +1,21 @@
 import React, { Context, ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import type { I18nConfig, LocaleContext } from '../../types';
 import type { BaseLocale, ImportedLocales } from 'international-types';
+
+import type { I18NProviderConfig, LocaleContext } from '../../types';
 import { flattenLocale } from '../../common/flatten-locale';
 
 type I18nProviderProps = {
   locale: string;
   fallback?: ReactElement | null;
   fallbackLocale?: Record<string, unknown>;
-  config?: I18nConfig;
+  config?: I18NProviderConfig;
   children: ReactNode;
 };
 
 export function createI18nProviderClient<Locale extends BaseLocale, LocalesKeys>(
   I18nClientContext: Context<LocaleContext<Locale> | null>,
   locales: ImportedLocales,
-  useCurrentLocale: (config?: I18nConfig) => LocalesKeys,
+  useCurrentLocale: (config?: I18NProviderConfig) => LocalesKeys,
 ) {
   return function I18nProviderClient({
     locale: baseLocale,

--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -1,21 +1,21 @@
 import React, { Context, ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import type { BaseLocale, ImportedLocales } from 'international-types';
 
-import type { I18NProviderConfig, LocaleContext } from '../../types';
+import type { I18nProviderConfig, LocaleContext } from '../../types';
 import { flattenLocale } from '../../common/flatten-locale';
 
 type I18nProviderProps = {
   locale: string;
   fallback?: ReactElement | null;
   fallbackLocale?: Record<string, unknown>;
-  config?: I18NProviderConfig;
+  config?: I18nProviderConfig;
   children: ReactNode;
 };
 
 export function createI18nProviderClient<Locale extends BaseLocale, LocalesKeys>(
   I18nClientContext: Context<LocaleContext<Locale> | null>,
   locales: ImportedLocales,
-  useCurrentLocale: (config?: I18NProviderConfig) => LocalesKeys,
+  useCurrentLocale: (config?: I18nProviderConfig) => LocalesKeys,
 ) {
   return function I18nProviderClient({
     locale: baseLocale,

--- a/packages/next-international/src/app/client/create-use-current-locale.ts
+++ b/packages/next-international/src/app/client/create-use-current-locale.ts
@@ -1,13 +1,14 @@
 import { useParams } from 'next/navigation';
 import { useMemo } from 'react';
-import { I18nConfig } from '../../types';
 
-const DEFAULT_SEGMENT = 'locale';
+import type { I18NProviderConfig } from '../../types';
+
+const DEFAULT_SEGMENT_NAME = 'locale';
 
 export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[]): () => LocalesKeys {
-  return function useCurrentLocale(config?: I18nConfig) {
+  return function useCurrentLocale(config?: I18NProviderConfig) {
     const params = useParams();
-    const segment = params[config?.segment ?? DEFAULT_SEGMENT];
+    const segment = params[config?.segmentName ?? DEFAULT_SEGMENT_NAME];
 
     return useMemo(() => {
       for (const locale of locales) {

--- a/packages/next-international/src/app/client/create-use-current-locale.ts
+++ b/packages/next-international/src/app/client/create-use-current-locale.ts
@@ -1,18 +1,22 @@
-import { usePathname } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { useMemo } from 'react';
+import { I18nConfig } from '../../types';
+
+const DEFAULT_SEGMENT = 'locale';
 
 export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[]): () => LocalesKeys {
-  return function useCurrentLocale() {
-    const path = usePathname();
+  return function useCurrentLocale(config?: I18nConfig) {
+    const params = useParams();
+    const segment = params[config?.segment ?? DEFAULT_SEGMENT];
 
     return useMemo(() => {
       for (const locale of locales) {
-        if (path.startsWith(`/${locale}`)) {
+        if (segment === locale) {
           return locale;
         }
       }
 
       throw new Error('Locale not found');
-    }, [path]);
+    }, [segment]);
   };
 }

--- a/packages/next-international/src/app/client/create-use-current-locale.ts
+++ b/packages/next-international/src/app/client/create-use-current-locale.ts
@@ -1,12 +1,12 @@
 import { useParams } from 'next/navigation';
 import { useMemo } from 'react';
 
-import type { I18NProviderConfig } from '../../types';
+import type { I18nProviderConfig } from '../../types';
 
 const DEFAULT_SEGMENT_NAME = 'locale';
 
 export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[]): () => LocalesKeys {
-  return function useCurrentLocale(config?: I18NProviderConfig) {
+  return function useCurrentLocale(config?: I18nProviderConfig) {
     const params = useParams();
     const segment = params[config?.segmentName ?? DEFAULT_SEGMENT_NAME];
 

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -1,42 +1,65 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const Response = NextResponse;
+import { LOCALE_COOKIE, LOCALE_HEADER } from '../../common/constants';
+import type { I18NMiddlewareConfig } from '../../types';
+
+const DEFAULT_STRATEGY = 'redirect';
 
 export function createI18nMiddleware<Locales extends readonly string[]>(
   locales: Locales,
   defaultLocale: Locales[number],
+  config?: I18NMiddlewareConfig,
 ) {
   return function I18nMiddleware(request: NextRequest) {
-    const pathname = request.nextUrl.pathname;
-    const pathnameIsMissingLocale = locales.every(
-      locale => !pathname.startsWith(`/${locale}/`) && pathname !== `/${locale}`,
-    );
+    const requestUrl = request.nextUrl.clone();
 
-    if (pathnameIsMissingLocale && pathname !== '/favicon.ico') {
-      let locale = request.cookies.get('Next-Locale')?.value;
+    const locale = localeFromRequest(request, locales, config?.contentNegotiator) ?? defaultLocale;
 
-      if (!locale) {
-        const acceptLanguage = request.headers.get('Accept-Language');
-        const acceptLanguageLocale = acceptLanguage?.split(',')?.[0]?.split('-')?.[0] ?? defaultLocale;
+    if (noLocalePrefix(locales, requestUrl.pathname)) {
+      const mappedUrl = requestUrl.clone();
+      mappedUrl.pathname = `/${locale}${mappedUrl.pathname}`;
 
-        locale = locales.includes(acceptLanguageLocale) ? acceptLanguageLocale : defaultLocale;
+      const strategy = config?.urlMappingStrategy ?? DEFAULT_STRATEGY;
+      if (strategy === 'redirect') {
+        const response = NextResponse.redirect(mappedUrl);
+        return addLocaleToResponse(response, locale);
+      } else if (strategy === 'rewrite') {
+        const response = NextResponse.rewrite(mappedUrl);
+        return addLocaleToResponse(response, locale);
+      } else {
+        throw new Error(`Invalid urlMappingStrategy: ${strategy}`);
       }
-
-      const response = Response.redirect(new URL(`/${locale}${pathname}`, request.url));
-
-      response.headers.set('X-Next-Locale', locale);
-
-      return response;
     }
 
-    const response = Response.next();
-    const locale = pathname.split('/')[1];
-
-    if (locales.includes(locale)) {
-      response.headers.set('X-Next-Locale', locale);
-      response.cookies.set('Next-Locale', locale);
-    }
-
-    return response;
+    const response = NextResponse.next();
+    return addLocaleToResponse(response, locale);
   };
+}
+
+function localeFromRequest(
+  request: NextRequest,
+  locales: readonly string[],
+  contentNegotiator?: (request: NextRequest, locales: readonly string[]) => string | null,
+) {
+  let locale = request.cookies.get(LOCALE_COOKIE)?.value ?? null;
+  if (!locale) {
+    locale = contentNegotiator ? contentNegotiator(request, locales) : negotiateAcceptLanguage(request);
+  }
+  return locale;
+}
+
+function negotiateAcceptLanguage(request: NextRequest) {
+  const header = request.headers.get('Accept-Language');
+  const locale = header?.split(',')?.[0]?.split('-')?.[0];
+  return locale ?? null;
+}
+
+function noLocalePrefix(locales: readonly string[], pathname: string) {
+  return locales.every(locale => !pathname.startsWith(`/${locale}`));
+}
+
+function addLocaleToResponse(response: NextResponse, locale: string) {
+  response.headers.set(LOCALE_HEADER, locale);
+  response.cookies.set(LOCALE_COOKIE, locale);
+  return response;
 }

--- a/packages/next-international/src/app/server/get-locale-cache.tsx
+++ b/packages/next-international/src/app/server/get-locale-cache.tsx
@@ -1,13 +1,15 @@
 import { cookies, headers } from 'next/headers';
 import { cache } from 'react';
 
+import { LOCALE_COOKIE, LOCALE_HEADER } from '../../common/constants';
+
 export const getLocaleCache = cache(() => {
   let locale: string | undefined | null;
 
-  locale = headers().get('X-Next-Locale');
+  locale = headers().get(LOCALE_HEADER);
 
   if (!locale) {
-    locale = cookies().get('Next-Locale')?.value;
+    locale = cookies().get(LOCALE_COOKIE)?.value;
   }
 
   if (!locale) {

--- a/packages/next-international/src/common/constants.ts
+++ b/packages/next-international/src/common/constants.ts
@@ -1,0 +1,2 @@
+export const LOCALE_HEADER = 'X-Next-Locale';
+export const LOCALE_COOKIE = 'Next-Locale';

--- a/packages/next-international/src/types.ts
+++ b/packages/next-international/src/types.ts
@@ -9,3 +9,14 @@ export type LocaleContext<Locale extends BaseLocale> = {
 export type LocaleMap<T> = Record<keyof T, React.ReactNode>;
 
 export type ReactParamsObject<Value extends LocaleValue> = Record<Params<Value>[number], React.ReactNode>;
+
+export type I18nConfig = {
+  /**
+   * The name of the Next.js layout segment param that will be used to determine the locale in a client component.
+   *
+   * An app directory folder hierarchy that looks like `app/[locale]/products/[category]/[subCategory]/page.tsx` would be `locale`.
+   *
+   * Default is `locale`
+   */
+  segment?: string;
+};

--- a/packages/next-international/src/types.ts
+++ b/packages/next-international/src/types.ts
@@ -1,5 +1,4 @@
 import type { BaseLocale, LocaleValue, Params } from 'international-types';
-import type { NextRequest } from 'next/server';
 
 export type LocaleContext<Locale extends BaseLocale> = {
   locale: string;
@@ -11,18 +10,18 @@ export type LocaleMap<T> = Record<keyof T, React.ReactNode>;
 
 export type ReactParamsObject<Value extends LocaleValue> = Record<Params<Value>[number], React.ReactNode>;
 
-export type I18NProviderConfig = {
+export type I18nProviderConfig = {
   /**
    * The name of the Next.js layout segment param that will be used to determine the locale in a client component.
    *
    * An app directory folder hierarchy that looks like `app/[locale]/products/[category]/[subCategory]/page.tsx` would be `locale`.
    *
-   * Default is `locale`
+   * @default locale
    */
   segmentName?: string;
 };
 
-export type I18NMiddlewareConfig = {
+export type I18nMiddlewareConfig = {
   /**
    * When a url is not prefixed with a locale, this setting determines whether the middleware should perform a *redirect* or *rewrite* to the default locale.
    *
@@ -30,30 +29,7 @@ export type I18NMiddlewareConfig = {
    *
    * **rewrite**: `https://example.com/products` -> *rewrite* to `https://example.com/en/products` -> client doesn't see the locale in the url
    *
-   * Default is `redirect`
+   * @default redirect
    */
   urlMappingStrategy?: 'redirect' | 'rewrite';
-
-  /**
-   * Specify a custom function to determine the locale from the request headers. It is recommended to use a standard content negotiation library like [negotiator](https://www.npmjs.com/package/negotiator) or [accept-negotiator](@fastify/accept-negotiator).
-   *  If the function returns `null`, the default locale will be used.
-   *
-   * The default implementation will look at the `Accept-Language` header and return the first locale.
-   *
-   * Example:
-   *
-   * ```ts
-   * import { negotiate } from "@fastify/accept-negotiator"
-   *
-   * const locales = ['en', 'fr'] as const
-   * const defaultLocale = 'fr'
-   * const I18nMiddleware = createI18nMiddleware(locales, defaultLocale, {
-   *  contentNegotiation: (request, locales) => {
-   *    const header = request.headers.get('Accept-Language') || ""
-   *    return negotiate(header, locales)
-   *  }
-   * })
-   * ```
-   */
-  contentNegotiator?: (request: NextRequest, locales: readonly string[]) => string | null;
 };

--- a/packages/next-international/src/types.ts
+++ b/packages/next-international/src/types.ts
@@ -1,4 +1,5 @@
 import type { BaseLocale, LocaleValue, Params } from 'international-types';
+import type { NextRequest } from 'next/server';
 
 export type LocaleContext<Locale extends BaseLocale> = {
   locale: string;
@@ -10,7 +11,7 @@ export type LocaleMap<T> = Record<keyof T, React.ReactNode>;
 
 export type ReactParamsObject<Value extends LocaleValue> = Record<Params<Value>[number], React.ReactNode>;
 
-export type I18nConfig = {
+export type I18NProviderConfig = {
   /**
    * The name of the Next.js layout segment param that will be used to determine the locale in a client component.
    *
@@ -18,5 +19,41 @@ export type I18nConfig = {
    *
    * Default is `locale`
    */
-  segment?: string;
+  segmentName?: string;
+};
+
+export type I18NMiddlewareConfig = {
+  /**
+   * When a url is not prefixed with a locale, this setting determines whether the middleware should perform a *redirect* or *rewrite* to the default locale.
+   *
+   * **redirect**: `https://example.com/products` -> *redirect* to `https://example.com/en/products` -> client sees the locale in the url
+   *
+   * **rewrite**: `https://example.com/products` -> *rewrite* to `https://example.com/en/products` -> client doesn't see the locale in the url
+   *
+   * Default is `redirect`
+   */
+  urlMappingStrategy?: 'redirect' | 'rewrite';
+
+  /**
+   * Specify a custom function to determine the locale from the request headers. It is recommended to use a standard content negotiation library like [negotiator](https://www.npmjs.com/package/negotiator) or [accept-negotiator](@fastify/accept-negotiator).
+   *  If the function returns `null`, the default locale will be used.
+   *
+   * The default implementation will look at the `Accept-Language` header and return the first locale.
+   *
+   * Example:
+   *
+   * ```ts
+   * import { negotiate } from "@fastify/accept-negotiator"
+   *
+   * const locales = ['en', 'fr'] as const
+   * const defaultLocale = 'fr'
+   * const I18nMiddleware = createI18nMiddleware(locales, defaultLocale, {
+   *  contentNegotiation: (request, locales) => {
+   *    const header = request.headers.get('Accept-Language') || ""
+   *    return negotiate(header, locales)
+   *  }
+   * })
+   * ```
+   */
+  contentNegotiator?: (request: NextRequest, locales: readonly string[]) => string | null;
 };


### PR DESCRIPTION
Closes #62 

This PR includes a few key updates.

### Replace `usePathname` with `useParams` 

`useParams` is a more reliable way to access the locale than `usePathname`. For example, calling `useParams` in `app/[locale]/products/[category]/[subCategory]/page.tsx` with the URL `/en/products/cars/trucks` returns `{ locale: 'en', category: 'cars', subCategory: 'trucks' }`.

When enabling the opt-in rewrite strategy, the request URLs not prefixed with the locale (e.g. `/products/cars/trucks`) are now supported. In this situation, using `usePathname` would return a URL without the locale (e.g. `/products/car/trucks`) while `useParams` still returns an object that contains the locale as the layout segment.

A config object is introduced with the `segmentName` option to allow users to change the segment name (default is `locale`) in case their layout segment is named something else.

```tsx
// app/[i18n]/layout.tsx
// ...
<I18nProviderClient
  locale={locale}
  config={{
    segmentName: "i18n",
  }}
>
  {children}
</I18nProviderClient>
```

### Opt-in rewrite url mapping strategy

By default, if a URL without the locale prefix (e.g. `/products/cars/trucks`) is received, the next-international middleware will perform a redirect to a version of the URL prefixed with the default locale (e.g. `/en/products/cars/trucks`) which will be visible to the user in the browsers address bar.

If developers would like the middleware to perform a [rewrite](https://nextjs.org/docs/app/api-reference/functions/next-response#rewrite) instead of a redirect in this situation such that the locale will not be visible, they can now specify that strategy in the middleware config.

```ts
const I18nMiddleware = createI18nMiddleware(['en', 'fr'] as const, 'fr', {
  urlMappingStrategy: "rewrite",
})
```
