### PR TITLE
fix(international-types): plurals params with scope

### DIFF
--- a/examples/next-app/app/[locale]/client/page.tsx
+++ b/examples/next-app/app/[locale]/client/page.tsx
@@ -65,6 +65,16 @@ export default function Client() {
           count: 2,
         })}
       </p>
+      <p>
+        {t2('stars', {
+          count: 1,
+        })}
+      </p>
+      <p>
+        {t2('stars', {
+          count: 2,
+        })}
+      </p>
       <button type="button" onClick={() => changeLocale('en')}>
         EN
       </button>

--- a/examples/next-app/app/[locale]/page.tsx
+++ b/examples/next-app/app/[locale]/page.tsx
@@ -65,6 +65,16 @@ export default async function Home() {
           count: 2,
         })}
       </p>
+      <p>
+        {t2('stars', {
+          count: 1,
+        })}
+      </p>
+      <p>
+        {t2('stars', {
+          count: 2,
+        })}
+      </p>
     </div>
   );
 }

--- a/examples/next-app/locales/en.ts
+++ b/examples/next-app/locales/en.ts
@@ -8,6 +8,8 @@ export default {
   'scope.more.test': 'A scope',
   'scope.more.param': 'A scope with {param}',
   'scope.more.and.more.test': 'A scope',
+  'scope.more.stars#one': '1 star on GitHub',
+  'scope.more.stars#other': '{count} stars on GitHub',
   'missing.translation.in.fr': 'This should work',
   'cows#one': 'A cow',
   'cows#other': '{count} cows',
@@ -30,6 +32,8 @@ export default {
 //           test: 'A scope',
 //         },
 //       },
+//       'stars#one': '1 star on GitHub',
+//       'stars#other': '{count} stars on GitHub',
 //     },
 //   },
 //   missing: {

--- a/examples/next-app/locales/fr.ts
+++ b/examples/next-app/locales/fr.ts
@@ -10,6 +10,8 @@ export default {
   'scope.more.test': 'Un scope',
   'scope.more.param': 'Un scope avec un {param}',
   'scope.more.and.more.test': 'Un scope',
+  'scope.more.stars#one': '1 étoile sur GitHub',
+  'scope.more.stars#other': '{count} étoiles sur GitHub',
   'missing.translation.in.fr': '', // Comment to test locale fallback
   'cows#one': 'Une vache',
   'cows#other': '{count} vaches',

--- a/examples/next-pages/locales/en.ts
+++ b/examples/next-pages/locales/en.ts
@@ -8,6 +8,8 @@ export default {
   'scope.more.test': 'A scope',
   'scope.more.param': 'A scope with {param}',
   'scope.more.and.more.test': 'A scope',
+  'scope.more.stars#one': '1 star on GitHub',
+  'scope.more.stars#other': '{count} stars on GitHub',
   'missing.translation.in.fr': 'This should work',
   'cows#one': 'A cow',
   'cows#other': '{count} cows',
@@ -30,6 +32,8 @@ export default {
 //           test: 'A scope',
 //         },
 //       },
+//       'stars#one': '1 star on GitHub',
+//       'stars#other': '{count} stars on GitHub',
 //     },
 //   },
 //   missing: {

--- a/examples/next-pages/locales/fr.ts
+++ b/examples/next-pages/locales/fr.ts
@@ -10,6 +10,8 @@ export default defineLocale({
   'scope.more.test': 'Un scope',
   'scope.more.param': 'Un scope avec un {param}',
   'scope.more.and.more.test': 'Un scope',
+  'scope.more.stars#one': '1 étoile sur GitHub',
+  'scope.more.stars#other': '{count} étoiles sur GitHub',
   'missing.translation.in.fr': '', // Comment to test locale fallback
   'cows#one': 'Une vache',
   'cows#other': '{count} vaches',

--- a/examples/next-pages/pages/index.tsx
+++ b/examples/next-pages/pages/index.tsx
@@ -62,6 +62,16 @@ export default function Home() {
           count: 2,
         })}
       </p>
+      <p>
+        {t2('stars', {
+          count: 1,
+        })}
+      </p>
+      <p>
+        {t2('stars', {
+          count: 2,
+        })}
+      </p>
       <button type="button" onClick={() => changeLocale('en')}>
         EN
       </button>

--- a/examples/next-pages/pages/ssr-ssg.tsx
+++ b/examples/next-pages/pages/ssr-ssg.tsx
@@ -54,6 +54,16 @@ export default function SSR() {
           count: 2,
         })}
       </p>
+      <p>
+        {t2('stars', {
+          count: 1,
+        })}
+      </p>
+      <p>
+        {t2('stars', {
+          count: 2,
+        })}
+      </p>
       <button type="button" onClick={() => changeLocale('en')}>
         EN
       </button>


### PR DESCRIPTION
Closes #87

When using `getScopedI18n` / `useScopedI18n`, we did not resolve the plural params by joining the Scope + Key and instead only used the Key to index the translation value.