### PR TITLE
fix(next-international): `useChangeLocale` with `basePath`

### DIFF
--- a/examples/next-app/app/[locale]/client/page.tsx
+++ b/examples/next-app/app/[locale]/client/page.tsx
@@ -4,7 +4,9 @@ import { useI18n, useScopedI18n, useChangeLocale, useCurrentLocale } from '../..
 
 export default function Client() {
   const t = useI18n();
-  const changeLocale = useChangeLocale();
+  const changeLocale = useChangeLocale({
+    // basePath: '/base',
+  });
   const t2 = useScopedI18n('scope.more');
   const locale = useCurrentLocale();
 

--- a/examples/next-app/app/[locale]/switch.tsx
+++ b/examples/next-app/app/[locale]/switch.tsx
@@ -3,7 +3,9 @@
 import { useChangeLocale } from '../../locales/client';
 
 export function Switch() {
-  const changeLocale = useChangeLocale();
+  const changeLocale = useChangeLocale({
+    // basePath: '/base',
+  });
 
   return (
     <>

--- a/examples/next-app/next.config.js
+++ b/examples/next-app/next.config.js
@@ -10,6 +10,8 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  // Uncomment to set base path
+  // basePath: '/base',
   // Uncomment to use SSG
   // output: 'export',
 };

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -544,6 +544,14 @@ export default function Page() {
 }
 ```
 
+If you have set a [`basePath`](https://nextjs.org/docs/app/api-reference/next-config-js/basePath) option inside `next.config.js`, you'll also need to set it here:
+
+```ts
+const changeLocale = useChangeLocale({
+  basePath: '/your-base-path'
+})
+```
+
 </details>
 
 ### Fallback locale for missing translations

--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -1,21 +1,21 @@
 import React, { Context, ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import type { BaseLocale, ImportedLocales } from 'international-types';
 
-import type { I18nProviderConfig, LocaleContext } from '../../types';
+import type { I18nCurrentLocaleConfig, LocaleContext } from '../../types';
 import { flattenLocale } from '../../common/flatten-locale';
 
 type I18nProviderProps = {
   locale: string;
   fallback?: ReactElement | null;
   fallbackLocale?: Record<string, unknown>;
-  config?: I18nProviderConfig;
+  config?: I18nCurrentLocaleConfig;
   children: ReactNode;
 };
 
 export function createI18nProviderClient<Locale extends BaseLocale, LocalesKeys>(
   I18nClientContext: Context<LocaleContext<Locale> | null>,
   locales: ImportedLocales,
-  useCurrentLocale: (config?: I18nProviderConfig) => LocalesKeys,
+  useCurrentLocale: (config?: I18nCurrentLocaleConfig) => LocalesKeys,
 ) {
   return function I18nProviderClient({
     locale: baseLocale,

--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -1,11 +1,16 @@
 import { useRouter, usePathname } from 'next/navigation';
+import type { I18nChangeLocaleConfig } from '../../types';
 
 export function createUseChangeLocale<LocalesKeys>(locales: LocalesKeys[]) {
-  return function useChangeLocale() {
+  return function useChangeLocale(config?: I18nChangeLocaleConfig) {
     const { push } = useRouter();
     const path = usePathname();
 
     let pathWithoutLocale = path;
+
+    if (config?.basePath) {
+      pathWithoutLocale = pathWithoutLocale.replace(config.basePath, '');
+    }
 
     locales.forEach(locale => {
       pathWithoutLocale = pathWithoutLocale.replace(`/${locale}`, '');

--- a/packages/next-international/src/app/client/create-use-current-locale.ts
+++ b/packages/next-international/src/app/client/create-use-current-locale.ts
@@ -1,12 +1,11 @@
 import { useParams } from 'next/navigation';
 import { useMemo } from 'react';
-
-import type { I18nProviderConfig } from '../../types';
+import type { I18nCurrentLocaleConfig } from '../../types';
 
 const DEFAULT_SEGMENT_NAME = 'locale';
 
 export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[]): () => LocalesKeys {
-  return function useCurrentLocale(config?: I18nProviderConfig) {
+  return function useCurrentLocale(config?: I18nCurrentLocaleConfig) {
     const params = useParams();
     const segment = params[config?.segmentName ?? DEFAULT_SEGMENT_NAME];
 

--- a/packages/next-international/src/types.ts
+++ b/packages/next-international/src/types.ts
@@ -10,7 +10,7 @@ export type LocaleMap<T> = Record<keyof T, React.ReactNode>;
 
 export type ReactParamsObject<Value extends LocaleValue> = Record<Params<Value>[number], React.ReactNode>;
 
-export type I18nProviderConfig = {
+export type I18nCurrentLocaleConfig = {
   /**
    * The name of the Next.js layout segment param that will be used to determine the locale in a client component.
    *
@@ -19,6 +19,15 @@ export type I18nProviderConfig = {
    * @default locale
    */
   segmentName?: string;
+};
+
+export type I18nChangeLocaleConfig = {
+  /**
+   * If you are using a custom basePath inside `next.config.js`, you must also specify it here.
+   *
+   * @see https://nextjs.org/docs/app/api-reference/next-config-js/basePath
+   */
+  basePath?: string;
 };
 
 export type I18nMiddlewareConfig = {


### PR DESCRIPTION
Closes #89 