### PR TITLE
fix(next-international): preserve search params with `useChangeLocale` in App Router

### DIFF
--- a/packages/next-international/package.json
+++ b/packages/next-international/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-international",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Type-safe internationalization (i18n) for Next.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -1,10 +1,11 @@
-import { useRouter, usePathname } from 'next/navigation';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import type { I18nChangeLocaleConfig } from '../../types';
 
 export function createUseChangeLocale<LocalesKeys>(locales: LocalesKeys[]) {
   return function useChangeLocale(config?: I18nChangeLocaleConfig) {
     const { push } = useRouter();
     const path = usePathname();
+    const searchParams = useSearchParams();
 
     let pathWithoutLocale = path;
 
@@ -17,7 +18,9 @@ export function createUseChangeLocale<LocalesKeys>(locales: LocalesKeys[]) {
     });
 
     return function changeLocale(newLocale: LocalesKeys) {
-      push(`/${newLocale}${pathWithoutLocale}`);
+      const search = searchParams.toString();
+
+      push(`/${newLocale}${pathWithoutLocale}${search ? `?${search}` : ''}`);
     };
   };
 }


### PR DESCRIPTION
Closes #92