### PR TITLE
preserve request headers

### DIFF
--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -35,7 +35,14 @@ export function createI18nMiddleware<Locales extends readonly string[]>(
       }
     }
 
-    const response = NextResponse.next();
+    const requestHeaders = new Headers(request.headers);
+
+    const response = NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    });
+
     const requestLocale = request.nextUrl.pathname.split('/')?.[1] ?? locale;
 
     if (locales.includes(requestLocale)) {


### PR DESCRIPTION
This PR fixes the issues resulting from overriding request headers
this override causes the static image to not load on client, but after this change it loads successfully. 