### PR TITLE
chore: update middleware regex

### DIFF
--- a/examples/next-app/middleware.ts
+++ b/examples/next-app/middleware.ts
@@ -8,5 +8,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!_next).*)'],
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
 };

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -223,7 +223,7 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!_next).*)']
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)']
 }
 ```
 


### PR DESCRIPTION
Relates to https://github.com/QuiiBz/next-international/issues/97, update the default middleware regex to not run on /api, /_next/static, /_next/image & /favicon.ico