### PR TITLE
feat(next-international): force default locale

### DIFF
--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -14,7 +14,11 @@ export function createI18nMiddleware<Locales extends readonly string[]>(
   return function I18nMiddleware(request: NextRequest) {
     const requestUrl = request.nextUrl.clone();
 
-    const locale = localeFromRequest(locales, request) ?? defaultLocale;
+    let locale = localeFromRequest(locales, request) ?? defaultLocale;
+
+    if (config?.forceDefaultLocale) {
+      locale = defaultLocale;
+    }
 
     if (noLocalePrefix(locales, requestUrl.pathname)) {
       const mappedUrl = requestUrl.clone();

--- a/packages/next-international/src/types.ts
+++ b/packages/next-international/src/types.ts
@@ -41,4 +41,11 @@ export type I18nMiddlewareConfig = {
    * @default redirect
    */
   urlMappingStrategy?: 'redirect' | 'rewrite';
+
+  /**
+   * Force to use the default locale instead of trying to extract the user's preferred locale.
+   *
+   * @default false
+   */
+  forceDefaultLocale?: boolean;
 };


### PR DESCRIPTION
Relates to #108

Add a new `forceDefaultLocale` option inside `createI18nMiddleware` to force the usage of the default locale.