### PR TITLE
feat(next-international): override locale resolution

### DIFF
--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -22,6 +22,7 @@
   - [Fallback locale for missing translations](#fallback-locale-for-missing-translations)
   - [Load initial locales client-side](#load-initial-locales-client-side)
   - [Rewrite the URL to hide the locale](#rewrite-the-url-to-hide-the-locale)
+  - [Override the user's locale resolution](#override-the-user-s-locale-resolution)
   - [Use the types for my own library](#use-the-types-for-my-own-library)
   - [Testing](#testing)
 - [License](#license)
@@ -593,7 +594,23 @@ Navigate to the `middleware.ts` file and set the `urlMappingStrategy` to `rewrit
 ```ts
 // middleware.ts
 const I18nMiddleware = createI18nMiddleware(['en', 'fr'] as const, 'fr', {
-    urlMappingStrategy: 'rewrite'
+  urlMappingStrategy: 'rewrite'
+})
+```
+
+### Override the user's locale resolution
+
+If needed, you can override the resolution of a locale from a `Request`, which by default will try to extract it from the `Accept-Language` header. This can be useful to force the use of a specific locale regardless of the `Accept-Language` header. Note that this function will only be called if the user doesn't already have a `Next-Locale` cookie.
+
+Navigate to the `middleware.ts` file and implement a new `resolveLocaleFromRequest` function:
+
+```ts
+// middleware.ts
+const I18nMiddleware = createI18nMiddleware(['en', 'fr'] as const, 'fr', {
+  resolveLocaleFromRequest: request => {
+    // Do your logic here to resolve the locale
+    return 'fr'
+  }
 })
 ```
 

--- a/packages/next-international/src/types.ts
+++ b/packages/next-international/src/types.ts
@@ -1,4 +1,5 @@
 import type { BaseLocale, LocaleValue, Params } from 'international-types';
+import type { NextRequest } from 'next/server';
 
 export type LocaleContext<Locale extends BaseLocale> = {
   locale: string;
@@ -30,7 +31,7 @@ export type I18nChangeLocaleConfig = {
   basePath?: string;
 };
 
-export type I18nMiddlewareConfig = {
+export type I18nMiddlewareConfig<Locales extends readonly string[]> = {
   /**
    * When a url is not prefixed with a locale, this setting determines whether the middleware should perform a *redirect* or *rewrite* to the default locale.
    *
@@ -41,4 +42,11 @@ export type I18nMiddlewareConfig = {
    * @default redirect
    */
   urlMappingStrategy?: 'redirect' | 'rewrite';
+
+  /**
+   * Override the resolution of a locale from a `Request`, which by default will try to extract it from the `Accept-Language` header. This can be useful to force the use of a specific locale regardless of the `Accept-Language` header.
+   *
+   * @description This function will only be called if the user doesn't already have a `Next-Locale` cookie.
+   */
+  resolveLocaleFromRequest?: (request: NextRequest) => Locales[number] | null;
 };


### PR DESCRIPTION
Closes #110
Relates to #96
Relates to #108

If needed, you can override the resolution of a locale from a `Request`, which by default will try to extract it from the `Accept-Language` header. This can be useful to force the use of a specific locale regardless of the `Accept-Language` header. Note that this function will only be called if the user doesn't already have a `Next-Locale` cookie.

Navigate to the `middleware.ts` file and implement a new `resolveLocaleFromRequest` function:

```ts
// middleware.ts
const I18nMiddleware = createI18nMiddleware(['en', 'fr'] as const, 'fr', {
  resolveLocaleFromRequest: request => {
    // Do your logic here to resolve the locale
    return 'fr'
  }
})
```