### PR TITLE
fix(next-international): pathname starting with locale error

### DIFF
--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -73,7 +73,9 @@ const defaultResolveLocaleFromRequest: NonNullable<I18nMiddlewareConfig<any>['re
 };
 
 function noLocalePrefix(locales: readonly string[], pathname: string) {
-  return locales.every(locale => !pathname.startsWith(`/${locale}`));
+  return locales.every(locale => {
+    return !(pathname === `/${locale}` || pathname.startsWith(`/${locale}/`));
+  });
 }
 
 function addLocaleToResponse(response: NextResponse, locale: string) {


### PR DESCRIPTION
Relates to #109

Fix an error when navigating to pathnames that start with a locale (e.g `en` locale with a path `/enna` would error instead of redirecting to `/en/enna`)