### PR TITLE
fix(next-international): update middleware matcher to work with images

### DIFF
--- a/examples/next-app/middleware.ts
+++ b/examples/next-app/middleware.ts
@@ -8,5 +8,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/((?!api|static|.*\\..*|_next|favicon.ico|robots.txt).*)'],
 };

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -226,7 +226,7 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)']
+  matcher: ['/((?!api|static|.*\\..*|_next|favicon.ico|robots.txt).*)'],
 }
 ```
 


### PR DESCRIPTION
Closes #118

Also ignore `favicon.ico` and `robots.txt`