### PR TITLE
fix(next-international): type of `useCurrentLocale`

### DIFF
--- a/packages/next-international/src/app/client/create-use-current-locale.ts
+++ b/packages/next-international/src/app/client/create-use-current-locale.ts
@@ -4,7 +4,7 @@ import type { I18nCurrentLocaleConfig } from '../../types';
 
 const DEFAULT_SEGMENT_NAME = 'locale';
 
-export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[]): () => LocalesKeys {
+export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[]) {
   return function useCurrentLocale(config?: I18nCurrentLocaleConfig) {
     const params = useParams();
     const segment = params[config?.segmentName ?? DEFAULT_SEGMENT_NAME];


### PR DESCRIPTION
Relates to #122

Remove the return type of `createUseCurrentLocale` to keep it inferred and allow passing a config to `useCurrentLocale`.