### PR TITLE
feat(next-international): allow configuring segment name in `getStaticParams`

### DIFF
--- a/packages/next-international/src/app/client/create-use-current-locale.ts
+++ b/packages/next-international/src/app/client/create-use-current-locale.ts
@@ -1,8 +1,7 @@
 import { useParams } from 'next/navigation';
 import { useMemo } from 'react';
 import type { I18nCurrentLocaleConfig } from '../../types';
-
-const DEFAULT_SEGMENT_NAME = 'locale';
+import { DEFAULT_SEGMENT_NAME } from '../../common/constants';
 
 export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[]) {
   return function useCurrentLocale(config?: I18nCurrentLocaleConfig) {

--- a/packages/next-international/src/app/server/create-get-static-params.ts
+++ b/packages/next-international/src/app/server/create-get-static-params.ts
@@ -1,9 +1,11 @@
 import type { ImportedLocales } from 'international-types';
+import { I18nStaticParamsConfig } from '../../types';
+import { DEFAULT_SEGMENT_NAME } from '../../common/constants';
 
 export function createGetStaticParams<Locales extends ImportedLocales>(locales: Locales) {
-  return function getStaticParams() {
+  return function getStaticParams(config?: I18nStaticParamsConfig) {
     return Object.keys(locales).map(locale => ({
-      locale,
+      [config?.segmentName ?? DEFAULT_SEGMENT_NAME]: locale,
     }));
   };
 }

--- a/packages/next-international/src/common/constants.ts
+++ b/packages/next-international/src/common/constants.ts
@@ -1,2 +1,3 @@
 export const LOCALE_HEADER = 'X-Next-Locale';
 export const LOCALE_COOKIE = 'Next-Locale';
+export const DEFAULT_SEGMENT_NAME = 'locale';

--- a/packages/next-international/src/types.ts
+++ b/packages/next-international/src/types.ts
@@ -22,6 +22,17 @@ export type I18nCurrentLocaleConfig = {
   segmentName?: string;
 };
 
+export type I18nStaticParamsConfig = {
+  /**
+   * The name of the Next.js layout segment param that will be used to determine the locale in a client component.
+   *
+   * An app directory folder hierarchy that looks like `app/[locale]/products/[category]/[subCategory]/page.tsx` would be `locale`.
+   *
+   * @default locale
+   */
+  segmentName?: string;
+};
+
 export type I18nChangeLocaleConfig = {
   /**
    * If you are using a custom basePath inside `next.config.js`, you must also specify it here.


### PR DESCRIPTION
Relates to https://github.com/QuiiBz/next-international/issues/122#issuecomment-1684208680