### PR TITLE
feat(next-international): improve config API

### DIFF
--- a/examples/next-app/app/[locale]/client/page.tsx
+++ b/examples/next-app/app/[locale]/client/page.tsx
@@ -4,9 +4,7 @@ import { useI18n, useScopedI18n, useChangeLocale, useCurrentLocale } from '../..
 
 export default function Client() {
   const t = useI18n();
-  const changeLocale = useChangeLocale({
-    // basePath: '/base',
-  });
+  const changeLocale = useChangeLocale();
   const t2 = useScopedI18n('scope.more');
   const locale = useCurrentLocale();
 

--- a/examples/next-app/app/[locale]/switch.tsx
+++ b/examples/next-app/app/[locale]/switch.tsx
@@ -3,9 +3,7 @@
 import { useChangeLocale } from '../../locales/client';
 
 export function Switch() {
-  const changeLocale = useChangeLocale({
-    // basePath: '/base',
-  });
+  const changeLocale = useChangeLocale();
 
   return (
     <>

--- a/examples/next-app/locales/client.ts
+++ b/examples/next-app/locales/client.ts
@@ -1,7 +1,15 @@
 import { createI18nClient } from 'next-international/client';
 
 export const { useI18n, useScopedI18n, I18nProviderClient, useChangeLocale, defineLocale, useCurrentLocale } =
-  createI18nClient({
-    en: () => import('./en'),
-    fr: () => import('./fr'),
-  });
+  createI18nClient(
+    {
+      en: () => import('./en'),
+      fr: () => import('./fr'),
+    },
+    {
+      // Uncomment to set base path
+      // basePath: '/base',
+      // Uncomment to use custom segment name
+      // segmentName: 'locale',
+    },
+  );

--- a/examples/next-app/locales/server.ts
+++ b/examples/next-app/locales/server.ts
@@ -1,6 +1,12 @@
 import { createI18nServer } from 'next-international/server';
 
-export const { getI18n, getScopedI18n, getCurrentLocale, getStaticParams } = createI18nServer({
-  en: () => import('./en'),
-  fr: () => import('./fr'),
-});
+export const { getI18n, getScopedI18n, getCurrentLocale, getStaticParams } = createI18nServer(
+  {
+    en: () => import('./en'),
+    fr: () => import('./fr'),
+  },
+  {
+    // Uncomment to use custom segment name
+    // segmentName: 'locale',
+  },
+);

--- a/packages/next-international/README.md
+++ b/packages/next-international/README.md
@@ -547,14 +547,6 @@ export default function Page() {
 }
 ```
 
-If you have set a [`basePath`](https://nextjs.org/docs/app/api-reference/next-config-js/basePath) option inside `next.config.js`, you'll also need to set it here:
-
-```ts
-const changeLocale = useChangeLocale({
-  basePath: '/your-base-path'
-})
-```
-
 </details>
 
 ### Fallback locale for missing translations

--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -1,30 +1,28 @@
 import React, { Context, ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import type { BaseLocale, ImportedLocales } from 'international-types';
 
-import type { I18nCurrentLocaleConfig, LocaleContext } from '../../types';
+import type { LocaleContext } from '../../types';
 import { flattenLocale } from '../../common/flatten-locale';
 
 type I18nProviderProps = {
   locale: string;
   fallback?: ReactElement | null;
   fallbackLocale?: Record<string, unknown>;
-  config?: I18nCurrentLocaleConfig;
   children: ReactNode;
 };
 
 export function createI18nProviderClient<Locale extends BaseLocale, LocalesKeys>(
   I18nClientContext: Context<LocaleContext<Locale> | null>,
   locales: ImportedLocales,
-  useCurrentLocale: (config?: I18nCurrentLocaleConfig) => LocalesKeys,
+  useCurrentLocale: () => LocalesKeys,
 ) {
   return function I18nProviderClient({
     locale: baseLocale,
     fallback = null,
     fallbackLocale,
     children,
-    config,
   }: I18nProviderProps) {
-    const locale = useCurrentLocale(config);
+    const locale = useCurrentLocale();
     const [clientLocale, setClientLocale] = useState<Locale>();
 
     const loadLocale = useCallback((locale: string) => {

--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -1,15 +1,15 @@
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
-import type { I18nChangeLocaleConfig } from '../../types';
+import type { I18nClientConfig } from '../../types';
 
-export function createUseChangeLocale<LocalesKeys>(locales: LocalesKeys[]) {
-  return function useChangeLocale(config?: I18nChangeLocaleConfig) {
+export function createUseChangeLocale<LocalesKeys>(locales: LocalesKeys[], config: I18nClientConfig) {
+  return function useChangeLocale() {
     const { push } = useRouter();
     const path = usePathname();
     const searchParams = useSearchParams();
 
     let pathWithoutLocale = path;
 
-    if (config?.basePath) {
+    if (config.basePath) {
       pathWithoutLocale = pathWithoutLocale.replace(config.basePath, '');
     }
 

--- a/packages/next-international/src/app/client/create-use-current-locale.ts
+++ b/packages/next-international/src/app/client/create-use-current-locale.ts
@@ -1,12 +1,12 @@
 import { useParams } from 'next/navigation';
 import { useMemo } from 'react';
-import type { I18nCurrentLocaleConfig } from '../../types';
 import { DEFAULT_SEGMENT_NAME } from '../../common/constants';
+import { I18nClientConfig } from '../../types';
 
-export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[]) {
-  return function useCurrentLocale(config?: I18nCurrentLocaleConfig) {
+export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[], config: I18nClientConfig) {
+  return function useCurrentLocale() {
     const params = useParams();
-    const segment = params[config?.segmentName ?? DEFAULT_SEGMENT_NAME];
+    const segment = params[config.segmentName ?? DEFAULT_SEGMENT_NAME];
 
     return useMemo(() => {
       for (const locale of locales) {

--- a/packages/next-international/src/app/client/index.ts
+++ b/packages/next-international/src/app/client/index.ts
@@ -1,6 +1,6 @@
 import 'client-only';
 import type { ExplicitLocales, FlattenLocale, GetLocaleType, ImportedLocales } from 'international-types';
-import type { LocaleContext } from '../../types';
+import type { I18nClientConfig, LocaleContext } from '../../types';
 import { createI18nProviderClient } from './create-i18n-provider-client';
 import { createContext } from 'react';
 import { createUsei18n } from '../../common/create-use-i18n';
@@ -11,6 +11,7 @@ import { createUseCurrentLocale } from './create-use-current-locale';
 
 export function createI18nClient<Locales extends ImportedLocales, OtherLocales extends ExplicitLocales | null = null>(
   locales: Locales,
+  config: I18nClientConfig = {},
 ) {
   type TempLocale = OtherLocales extends ExplicitLocales ? GetLocaleType<OtherLocales> : GetLocaleType<Locales>;
   type Locale = TempLocale extends Record<string, string> ? TempLocale : FlattenLocale<TempLocale>;
@@ -22,7 +23,7 @@ export function createI18nClient<Locales extends ImportedLocales, OtherLocales e
   // @ts-expect-error deep type
   const I18nClientContext = createContext<LocaleContext<Locale> | null>(null);
 
-  const useCurrentLocale = createUseCurrentLocale<LocalesKeys>(localesKeys);
+  const useCurrentLocale = createUseCurrentLocale<LocalesKeys>(localesKeys, config);
   const I18nProviderClient = createI18nProviderClient<Locale, LocalesKeys>(
     I18nClientContext,
     locales,
@@ -30,7 +31,7 @@ export function createI18nClient<Locales extends ImportedLocales, OtherLocales e
   );
   const useI18n = createUsei18n(I18nClientContext);
   const useScopedI18n = createScopedUsei18n(I18nClientContext);
-  const useChangeLocale = createUseChangeLocale<LocalesKeys>(localesKeys);
+  const useChangeLocale = createUseChangeLocale<LocalesKeys>(localesKeys, config);
   const defineLocale = createDefineLocale<Locale>();
 
   return {

--- a/packages/next-international/src/app/server/create-get-static-params.ts
+++ b/packages/next-international/src/app/server/create-get-static-params.ts
@@ -1,11 +1,11 @@
 import type { ImportedLocales } from 'international-types';
-import { I18nStaticParamsConfig } from '../../types';
+import { I18nServerConfig } from '../../types';
 import { DEFAULT_SEGMENT_NAME } from '../../common/constants';
 
-export function createGetStaticParams<Locales extends ImportedLocales>(locales: Locales) {
-  return function getStaticParams(config?: I18nStaticParamsConfig) {
+export function createGetStaticParams<Locales extends ImportedLocales>(locales: Locales, config: I18nServerConfig) {
+  return function getStaticParams() {
     return Object.keys(locales).map(locale => ({
-      [config?.segmentName ?? DEFAULT_SEGMENT_NAME]: locale,
+      [config.segmentName ?? DEFAULT_SEGMENT_NAME]: locale,
     }));
   };
 }

--- a/packages/next-international/src/app/server/index.ts
+++ b/packages/next-international/src/app/server/index.ts
@@ -5,9 +5,11 @@ import { createGetI18n } from './create-get-i18n';
 import { createGetScopedI18n } from './create-get-scoped-i18n';
 import { createGetCurrentLocale } from './create-get-current-locale';
 import { createGetStaticParams } from './create-get-static-params';
+import { I18nServerConfig } from '../../types';
 
 export function createI18nServer<Locales extends ImportedLocales, OtherLocales extends ExplicitLocales | null = null>(
   locales: Locales,
+  config: I18nServerConfig = {},
 ) {
   type TempLocale = OtherLocales extends ExplicitLocales ? GetLocaleType<OtherLocales> : GetLocaleType<Locales>;
   type Locale = TempLocale extends Record<string, string> ? TempLocale : FlattenLocale<TempLocale>;
@@ -18,7 +20,7 @@ export function createI18nServer<Locales extends ImportedLocales, OtherLocales e
   const getI18n = createGetI18n<Locale>(locales);
   const getScopedI18n = createGetScopedI18n<Locales, Locale>(locales);
   const getCurrentLocale = createGetCurrentLocale<LocalesKeys>();
-  const getStaticParams = createGetStaticParams(locales);
+  const getStaticParams = createGetStaticParams(locales, config);
 
   return {
     getI18n,

--- a/packages/next-international/src/types.ts
+++ b/packages/next-international/src/types.ts
@@ -11,7 +11,7 @@ export type LocaleMap<T> = Record<keyof T, React.ReactNode>;
 
 export type ReactParamsObject<Value extends LocaleValue> = Record<Params<Value>[number], React.ReactNode>;
 
-export type I18nCurrentLocaleConfig = {
+export type I18nClientConfig = {
   /**
    * The name of the Next.js layout segment param that will be used to determine the locale in a client component.
    *
@@ -20,26 +20,23 @@ export type I18nCurrentLocaleConfig = {
    * @default locale
    */
   segmentName?: string;
-};
-
-export type I18nStaticParamsConfig = {
-  /**
-   * The name of the Next.js layout segment param that will be used to determine the locale in a client component.
-   *
-   * An app directory folder hierarchy that looks like `app/[locale]/products/[category]/[subCategory]/page.tsx` would be `locale`.
-   *
-   * @default locale
-   */
-  segmentName?: string;
-};
-
-export type I18nChangeLocaleConfig = {
   /**
    * If you are using a custom basePath inside `next.config.js`, you must also specify it here.
    *
    * @see https://nextjs.org/docs/app/api-reference/next-config-js/basePath
    */
   basePath?: string;
+};
+
+export type I18nServerConfig = {
+  /**
+   * The name of the Next.js layout segment param that will be used to determine the locale in a client component.
+   *
+   * An app directory folder hierarchy that looks like `app/[locale]/products/[category]/[subCategory]/page.tsx` would be `locale`.
+   *
+   * @default locale
+   */
+  segmentName?: string;
 };
 
 export type I18nMiddlewareConfig<Locales extends readonly string[]> = {


### PR DESCRIPTION
## Improved config API

⚠️ BREAKING

Improve the API for configuring the App Router behaviors by moving all configurations from specific functions to `createI18n*` functions. This avoids duplicating multiple times the same configuration, and will allow for more configuration options in the future.

These changes are only affecting you if you were using these options.

### `basePath` config

Before:

```ts
// locales/client.ts
const { useChangeLocale } = createI18nClient({
  en: () => import('./en'),
  fr: () => import('./fr')
})

// In a Client Component
const changeLocale = useChangeLocale({
  basePath: '/base'
})
```

After:

```ts
// locales/client.ts
const { useChangeLocale } = createI18nClient({
  en: () => import('./en'),
  fr: () => import('./fr')
}, {
  basePath: '/base'
})

// In a Client Component
const changeLocale = useChangeLocale()
```

### `segmentName` config

Before:

```ts
// locales/client.ts
const { useCurrentLocale } = createI18nClient({
  en: () => import('./en'),
  fr: () => import('./fr')
})

// in a Client Component
const currentLocale = useCurrentLocale({
  segmentName: 'locale'
})

// locales/server.ts
export const { getStaticParams } = createI18nServer({
    en: () => import('./en'),
    fr: () => import('./fr')
})

// in a page
export function generateStaticParams() {
  return getStaticParams({
    segmentName: 'locale'
  })
}
```

After:

```ts
// locales/client.ts
const { useCurrentLocale } = createI18nClient({
  en: () => import('./en'),
  fr: () => import('./fr')
}, {
  segmentName: 'locale'
})

// in a Client Component
const currentLocale = useCurrentLocale()

// locales/server.ts
export const { getStaticParams } = createI18nServer({
    en: () => import('./en'),
    fr: () => import('./fr')
}, {
  segmentName: 'locale'
})

// in a page
export function generateStaticParams() {
  return getStaticParams()
}
```