### PR TITLE
chore: remove minify on build

### DIFF
--- a/packages/next-international/package.json
+++ b/packages/next-international/package.json
@@ -45,8 +45,8 @@
   "homepage": "https://github.com/QuiiBz/next-international#readme",
   "license": "MIT",
   "scripts": {
-    "build": "tsup src/index.ts src/app/client/index.ts src/app/server/index.ts src/app/middleware/index.ts --external next --external react --dts --minify",
-    "watch": "tsup src/index.ts src/app/client/index.ts src/app/server/index.ts src/app/middleware/index.ts --external next --external react --dts --watch"
+    "build": "tsup src/index.ts src/app/client/index.ts src/app/server/index.ts src/app/middleware/index.ts --external next --external react --dts",
+    "watch": "pnpm build --watch"
   },
   "devDependencies": {
     "@types/react": "^18.2.9",


### PR DESCRIPTION
Minifying is already done by Next.js, and it's harder to understand when digging inside `node_modules`