### PR TITLE
feat(next-international): remove locale for `useChangeLocale` with rewrite strate

### DIFF
--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -36,10 +36,17 @@ export function createI18nMiddleware<Locales extends readonly string[]>(
     }
 
     const response = NextResponse.next();
-    const requestLocale = request.nextUrl.pathname.split('/')?.[1] ?? locale;
+    const requestLocale = request.nextUrl.pathname.split('/')?.[1]
 
-    if (locales.includes(requestLocale)) {
+    if (requestLocale && config?.urlMappingStrategy === 'rewrite') {
+      const newUrl = new URL(request.nextUrl.pathname.slice(requestLocale.length + 1), request.url);
+      const response = NextResponse.redirect(newUrl);
+
       return addLocaleToResponse(response, requestLocale);
+    }
+
+    if (!requestLocale || locales.includes(requestLocale)) {
+      return addLocaleToResponse(response, requestLocale ?? defaultLocale);
     }
 
     return response;

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -36,9 +36,9 @@ export function createI18nMiddleware<Locales extends readonly string[]>(
     }
 
     const response = NextResponse.next();
-    const requestLocale = request.nextUrl.pathname.split('/')?.[1]
+    const requestLocale = request.nextUrl.pathname.split('/')?.[1];
 
-    if (requestLocale && config?.urlMappingStrategy === 'rewrite') {
+    if (locales.includes(requestLocale) && config?.urlMappingStrategy === 'rewrite') {
       const newUrl = new URL(request.nextUrl.pathname.slice(requestLocale.length + 1), request.url);
       const response = NextResponse.redirect(newUrl);
 


### PR DESCRIPTION
Relates to #136

When `urlMappingStrategy` is set to `rewrite`, we should redirect to the same URL without the locale when changing locale.