### PR TITLE
fix(next-international): `changeLocale` with subsequent navigations

### DIFF
--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -3,7 +3,7 @@ import type { I18nChangeLocaleConfig } from '../../types';
 
 export function createUseChangeLocale<LocalesKeys>(locales: LocalesKeys[]) {
   return function useChangeLocale(config?: I18nChangeLocaleConfig) {
-    const { push } = useRouter();
+    const { push, refresh } = useRouter();
     const path = usePathname();
     const searchParams = useSearchParams();
 
@@ -21,6 +21,7 @@ export function createUseChangeLocale<LocalesKeys>(locales: LocalesKeys[]) {
       const search = searchParams.toString();
 
       push(`/${newLocale}${pathWithoutLocale}${search ? `?${search}` : ''}`);
+      refresh();
     };
   };
 }


### PR DESCRIPTION
Relates to #138

The [Router Cache](https://nextjs.org/docs/app/building-your-application/caching#router-cache) of Next.js caches by route segments and causes issues when changing locale and navigating to already-viewed pages. Turns out we can simply call `router.refresh()` to invalidate the Router Cache and get the correct data for every page: https://nextjs.org/docs/app/building-your-application/caching#invalidation-1