### PR TITLE
feat(next-international): use `notFound()` instead of throwing un-catchable error

### DIFF
--- a/packages/next-international/src/app/client/create-use-current-locale.ts
+++ b/packages/next-international/src/app/client/create-use-current-locale.ts
@@ -1,7 +1,8 @@
-import { useParams } from 'next/navigation';
+import { notFound, useParams } from 'next/navigation';
 import { useMemo } from 'react';
 import { DEFAULT_SEGMENT_NAME } from '../../common/constants';
 import { I18nClientConfig } from '../../types';
+import { error } from '../../helpers/log';
 
 export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[], config: I18nClientConfig) {
   return function useCurrentLocale() {
@@ -15,7 +16,8 @@ export function createUseCurrentLocale<LocalesKeys>(locales: LocalesKeys[], conf
         }
       }
 
-      throw new Error('Locale not found');
+      error(`Locale "${segment}" not found in locales (${locales.join(', ')}), returning "notFound()"`);
+      notFound();
     }, [segment]);
   };
 }

--- a/packages/next-international/src/app/server/get-locale-cache.tsx
+++ b/packages/next-international/src/app/server/get-locale-cache.tsx
@@ -1,7 +1,8 @@
 import { cookies, headers } from 'next/headers';
 import { cache } from 'react';
-
 import { LOCALE_COOKIE, LOCALE_HEADER } from '../../common/constants';
+import { notFound } from 'next/navigation';
+import { error } from '../../helpers/log';
 
 export const getLocaleCache = cache(() => {
   let locale: string | undefined | null;
@@ -13,7 +14,8 @@ export const getLocaleCache = cache(() => {
   }
 
   if (!locale) {
-    throw new Error('Could not get the locale from the headers or cookies.');
+    error(`Locale not found in headers or cookies, returning "notFound()"`);
+    notFound();
   }
 
   return locale;


### PR DESCRIPTION
Relates to #144

## Allow catching not found locale errors (App Router)

When a locale can't be found, we now use [`notFound()`](https://nextjs.org/docs/app/api-reference/functions/not-found) instead of throwing an un-catchable error. This allows to render a [`not-found.ts`](https://nextjs.org/docs/app/api-reference/file-conventions/not-found) file easily.