### PR TITLE
refactor(next-international): load fallback locale immediately

### DIFF
--- a/docs/pages/docs/app-setup.mdx
+++ b/docs/pages/docs/app-setup.mdx
@@ -59,7 +59,7 @@ export default function SubLayout({ children }: { children: ReactElement }) {
 }
 ```
 
-You can also provide a `fallback` component prop to show while waiting for the locale to load.
+You can also provide a `fallback` component prop to show while waiting for the locale to load, and a `fallbackLocale` prop to specify a locale to fallback on if a key has not been translated.
 
 ### Setup Static Rendering (WIP)
 

--- a/docs/pages/docs/pages-setup.mdx
+++ b/docs/pages/docs/pages-setup.mdx
@@ -51,7 +51,7 @@ export default function App({ Component, pageProps }: AppProps) {
 }
 ```
 
-You can also provide a `fallback` component prop to show while waiting for the locale to load, and a `fallbackLocale` prop that will be used if a key has not been translated.
+You can also provide a `fallback` component prop to show while waiting for the locale to load, and a `fallbackLocale` prop to specify a locale to fallback on if a key has not been translated.
 
 ### Setup Static Site Generation or Rendering
 

--- a/examples/next-app/app/[locale]/client/layout.tsx
+++ b/examples/next-app/app/[locale]/client/layout.tsx
@@ -2,10 +2,11 @@
 
 import { ReactNode } from 'react';
 import { I18nProviderClient } from '../../../locales/client';
+import en from '../../../locales/en';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <I18nProviderClient fallback={<p> Loading...</p>} fallbackLocale="en">
+    <I18nProviderClient fallback={<p> Loading...</p>} fallbackLocale={en}>
       {children}
     </I18nProviderClient>
   );

--- a/examples/next-app/locales/server.ts
+++ b/examples/next-app/locales/server.ts
@@ -1,4 +1,5 @@
 import { createI18nServer } from 'next-international/server';
+// import en from './en';
 
 export const { getI18n, getScopedI18n, getCurrentLocale, getStaticParams } = createI18nServer(
   {
@@ -9,6 +10,6 @@ export const { getI18n, getScopedI18n, getCurrentLocale, getStaticParams } = cre
     // Uncomment to use custom segment name
     // segmentName: 'locale',
     // Uncomment to set fallback locale
-    // fallbackLocale: 'en',
+    // fallbackLocale: en,
   },
 );

--- a/examples/next-pages/pages/_app.tsx
+++ b/examples/next-pages/pages/_app.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { AppProps } from 'next/app';
 import { I18nProvider } from '../locales';
+import en from '../locales/en';
 
 const App = ({ Component, pageProps }: AppProps) => {
   return (
-    <I18nProvider locale={pageProps.locale} fallback={<p>Loading initial locale client-side</p>} fallbackLocale="en">
+    <I18nProvider locale={pageProps.locale} fallback={<p>Loading initial locale client-side</p>} fallbackLocale={en}>
       <Component {...pageProps} />
     </I18nProvider>
   );

--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -4,9 +4,9 @@ import type { BaseLocale, ImportedLocales } from 'international-types';
 import type { LocaleContext } from '../../types';
 import { flattenLocale } from '../../common/flatten-locale';
 
-type I18nProviderProps<LocalesKeys> = {
+type I18nProviderProps = {
   fallback?: ReactElement | null;
-  fallbackLocale?: LocalesKeys;
+  fallbackLocale?: BaseLocale;
   children: ReactNode;
 };
 
@@ -15,32 +15,24 @@ export function createI18nProviderClient<Locale extends BaseLocale, LocalesKeys>
   locales: ImportedLocales,
   useCurrentLocale: () => LocalesKeys,
 ) {
-  return function I18nProviderClient({ fallback = null, fallbackLocale, children }: I18nProviderProps<LocalesKeys>) {
+  return function I18nProviderClient({ fallback = null, fallbackLocale, children }: I18nProviderProps) {
     const locale = useCurrentLocale();
     const [clientLocale, setClientLocale] = useState<Locale>();
-    const [clientFallbackLocale, setClientFallbackLocale] = useState<Locale>();
 
     useEffect(() => {
       // @ts-expect-error any type
       locales[locale]().then(content => {
         setClientLocale(flattenLocale<Locale>(content.default));
       });
-
-      if (fallbackLocale) {
-        // @ts-expect-error any type
-        locales[fallbackLocale]().then(content => {
-          setClientFallbackLocale(flattenLocale<Locale>(content.default));
-        });
-      }
     }, [locale, fallbackLocale]);
 
     const value = useMemo(
       () => ({
         localeContent: clientLocale as Locale,
-        fallbackLocale: clientFallbackLocale as Locale | undefined,
+        fallbackLocale: fallbackLocale ? flattenLocale<Locale>(fallbackLocale) : undefined,
         locale: locale as string,
       }),
-      [clientLocale, clientFallbackLocale, locale],
+      [clientLocale, fallbackLocale, locale],
     );
 
     if (!clientLocale && fallback) {

--- a/packages/next-international/src/app/server/create-get-i18n.ts
+++ b/packages/next-international/src/app/server/create-get-i18n.ts
@@ -6,7 +6,7 @@ import { flattenLocale } from '../../common/flatten-locale';
 
 export function createGetI18n<Locales extends ImportedLocales, Locale extends BaseLocale>(
   locales: Locales,
-  config: I18nServerConfig<keyof Locales>,
+  config: I18nServerConfig,
 ) {
   return async function getI18n() {
     const locale = getLocaleCache();
@@ -14,9 +14,7 @@ export function createGetI18n<Locales extends ImportedLocales, Locale extends Ba
     return createT(
       {
         localeContent: flattenLocale((await locales[locale]()).default),
-        fallbackLocale: config.fallbackLocale
-          ? flattenLocale((await locales[config.fallbackLocale]()).default)
-          : undefined,
+        fallbackLocale: config.fallbackLocale ? flattenLocale(config.fallbackLocale) : undefined,
         locale,
       } as LocaleContext<Locale>,
       undefined,

--- a/packages/next-international/src/app/server/create-get-scoped-i18n.ts
+++ b/packages/next-international/src/app/server/create-get-scoped-i18n.ts
@@ -6,7 +6,7 @@ import { flattenLocale } from '../../common/flatten-locale';
 
 export function createGetScopedI18n<Locales extends ImportedLocales, Locale extends BaseLocale>(
   locales: Locales,
-  config: I18nServerConfig<keyof Locales>,
+  config: I18nServerConfig,
 ) {
   return async function getScopedI18n<Scope extends Scopes<Locale>>(scope: Scope) {
     const locale = getLocaleCache();
@@ -14,9 +14,7 @@ export function createGetScopedI18n<Locales extends ImportedLocales, Locale exte
     return createT(
       {
         localeContent: flattenLocale((await locales[locale]()).default),
-        fallbackLocale: config.fallbackLocale
-          ? flattenLocale((await locales[config.fallbackLocale]()).default)
-          : undefined,
+        fallbackLocale: config.fallbackLocale ? flattenLocale(config.fallbackLocale) : undefined,
         locale,
       } as LocaleContext<Locale>,
       scope,

--- a/packages/next-international/src/app/server/create-get-static-params.ts
+++ b/packages/next-international/src/app/server/create-get-static-params.ts
@@ -2,10 +2,7 @@ import type { ImportedLocales } from 'international-types';
 import { I18nServerConfig } from '../../types';
 import { DEFAULT_SEGMENT_NAME } from '../../common/constants';
 
-export function createGetStaticParams<Locales extends ImportedLocales>(
-  locales: Locales,
-  config: I18nServerConfig<keyof Locales>,
-) {
+export function createGetStaticParams<Locales extends ImportedLocales>(locales: Locales, config: I18nServerConfig) {
   return function getStaticParams() {
     return Object.keys(locales).map(locale => ({
       [config.segmentName ?? DEFAULT_SEGMENT_NAME]: locale,

--- a/packages/next-international/src/app/server/index.ts
+++ b/packages/next-international/src/app/server/index.ts
@@ -9,7 +9,7 @@ import { I18nServerConfig } from '../../types';
 
 export function createI18nServer<Locales extends ImportedLocales, OtherLocales extends ExplicitLocales | null = null>(
   locales: Locales,
-  config: I18nServerConfig<keyof Locales> = {},
+  config: I18nServerConfig = {},
 ) {
   type TempLocale = OtherLocales extends ExplicitLocales ? GetLocaleType<OtherLocales> : GetLocaleType<Locales>;
   type Locale = TempLocale extends Record<string, string> ? TempLocale : FlattenLocale<TempLocale>;

--- a/packages/next-international/src/pages/create-i18n-provider.tsx
+++ b/packages/next-international/src/pages/create-i18n-provider.tsx
@@ -5,14 +5,14 @@ import { useRouter } from 'next/router';
 import { error, warn } from '../helpers/log';
 import { flattenLocale } from '../common/flatten-locale';
 
-type I18nProviderProps<Locale extends BaseLocale, LocalesKeys> = {
+type I18nProviderProps<Locale extends BaseLocale> = {
   locale: Locale;
   fallback?: ReactElement | null;
-  fallbackLocale?: LocalesKeys;
+  fallbackLocale?: BaseLocale;
   children: ReactNode;
 };
 
-export function createI18nProvider<Locale extends BaseLocale, LocalesKeys>(
+export function createI18nProvider<Locale extends BaseLocale>(
   I18nContext: Context<LocaleContext<Locale> | null>,
   locales: ImportedLocales,
 ) {
@@ -21,10 +21,9 @@ export function createI18nProvider<Locale extends BaseLocale, LocalesKeys>(
     fallback = null,
     fallbackLocale,
     children,
-  }: I18nProviderProps<Locale, LocalesKeys>) {
+  }: I18nProviderProps<Locale>) {
     const { locale, defaultLocale, locales: nextLocales } = useRouter();
     const [clientLocale, setClientLocale] = useState<Locale>();
-    const [clientFallbackLocale, setClientFallbackLocale] = useState<Locale>();
     const initialLoadRef = useRef(true);
 
     useEffect(() => {
@@ -66,22 +65,13 @@ export function createI18nProvider<Locale extends BaseLocale, LocalesKeys>(
       initialLoadRef.current = false;
     }, [baseLocale, loadLocale, locale]);
 
-    useEffect(() => {
-      if (fallbackLocale) {
-        // @ts-expect-error any type
-        locales[fallbackLocale]().then(content => {
-          setClientFallbackLocale(flattenLocale<Locale>(content.default));
-        });
-      }
-    }, [fallbackLocale]);
-
     const value = useMemo(
       () => ({
         localeContent: (clientLocale || baseLocale) as Locale,
-        fallbackLocale: clientFallbackLocale,
+        fallbackLocale: fallbackLocale ? flattenLocale<Locale>(fallbackLocale) : undefined,
         locale: locale ?? defaultLocale ?? '',
       }),
-      [clientLocale, baseLocale, clientFallbackLocale, locale, defaultLocale],
+      [clientLocale, baseLocale, fallbackLocale, locale, defaultLocale],
     );
 
     if (!locale || !defaultLocale) {

--- a/packages/next-international/src/pages/index.ts
+++ b/packages/next-international/src/pages/index.ts
@@ -19,7 +19,7 @@ export function createI18n<Locales extends ImportedLocales, OtherLocales extends
 
   // @ts-expect-error deep type
   const I18nContext = createContext<LocaleContext<Locale> | null>(null);
-  const I18nProvider = createI18nProvider<Locale, LocalesKeys>(I18nContext, locales);
+  const I18nProvider = createI18nProvider<Locale>(I18nContext, locales);
   const useI18n = createUsei18n(I18nContext);
   const useScopedI18n = createScopedUsei18n(I18nContext);
   const useChangeLocale = createUseChangeLocale<LocalesKeys>();

--- a/packages/next-international/src/types.ts
+++ b/packages/next-international/src/types.ts
@@ -28,7 +28,7 @@ export type I18nClientConfig = {
   basePath?: string;
 };
 
-export type I18nServerConfig<LocalesKeys> = {
+export type I18nServerConfig = {
   /**
    * The name of the Next.js layout segment param that will be used to determine the locale in a client component.
    *
@@ -38,9 +38,9 @@ export type I18nServerConfig<LocalesKeys> = {
    */
   segmentName?: string;
   /**
-   * The name of the locale to use if some keys aren't translated, to fallback to this locale instead of showing the translation key.
+   * A locale to use if some keys aren't translated, to fallback to this locale instead of showing the translation key.
    */
-  fallbackLocale?: LocalesKeys;
+  fallbackLocale?: BaseLocale;
 };
 
 export type I18nMiddlewareConfig<Locales extends readonly string[]> = {


### PR DESCRIPTION
Relates to #149

Partial revert of https://github.com/QuiiBz/next-international/pull/142 to immediately get access to the fallback locale, which is either way always loaded on the client. This provides a better UX.