### PR TITLE
chore(docs): add bun installation support

### DIFF
--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -1,5 +1,5 @@
-import { Tabs, Tab, Cards, Card } from 'nextra/components';
-import { AppIcon, PagesIcon } from '../../components/icons';
+import { Tabs, Tab, Cards, Card } from 'nextra/components'
+import { AppIcon, PagesIcon } from '../../components/icons'
 
 # Get Started
 
@@ -9,10 +9,7 @@ import { AppIcon, PagesIcon } from '../../components/icons';
 - **Small**: No dependencies, lazy-loaded
 - **Simple**: No Webpack configuration, no CLI, no code generation, just pure TypeScript
 - **Server and Client, Static Rendering**: Lazy-load server and client-side, support for Static Rendering
-- <strong style={{ display: 'inline-flex', gap: '8px', verticalAlign: 'top' }}>
-    <AppIcon /> App or <PagesIcon /> Pages Router
-  </strong>
-  : With support for React Server Components
+- <strong style={{ display: 'inline-flex', gap: '8px', verticalAlign: 'top' }}><AppIcon /> App or <PagesIcon /> Pages Router</strong>: With support for React Server Components
 
 Try it live on CodeSandbox:
 

--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -1,5 +1,5 @@
-import { Tabs, Tab, Cards, Card } from 'nextra/components'
-import { AppIcon, PagesIcon } from '../../components/icons'
+import { Tabs, Tab, Cards, Card } from 'nextra/components';
+import { AppIcon, PagesIcon } from '../../components/icons';
 
 # Get Started
 
@@ -9,7 +9,10 @@ import { AppIcon, PagesIcon } from '../../components/icons'
 - **Small**: No dependencies, lazy-loaded
 - **Simple**: No Webpack configuration, no CLI, no code generation, just pure TypeScript
 - **Server and Client, Static Rendering**: Lazy-load server and client-side, support for Static Rendering
-- <strong style={{ display: 'inline-flex', gap: '8px', verticalAlign: 'top' }}><AppIcon /> App or <PagesIcon /> Pages Router</strong>: With support for React Server Components
+- <strong style={{ display: 'inline-flex', gap: '8px', verticalAlign: 'top' }}>
+    <AppIcon /> App or <PagesIcon /> Pages Router
+  </strong>
+  : With support for React Server Components
 
 Try it live on CodeSandbox:
 
@@ -18,26 +21,10 @@ Try it live on CodeSandbox:
 ## Installation
 
 <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>
-    ```bash
-    pnpm install next-international
-    ```
-  </Tab>
-  <Tab>
-    ```bash
-    npm install next-international
-    ```
-  </Tab>
-  <Tab>
-    ```bash
-    yarn add next-international
-    ```
-  </Tab>
-  <Tab>
-    ```bash
-    bun add next-international
-    ```
-  </Tab>
+  <Tab>```bash pnpm install next-international ```</Tab>
+  <Tab>```bash npm install next-international ```</Tab>
+  <Tab>```bash yarn add next-international ```</Tab>
+  <Tab>```bash bun add next-international ```</Tab>
 </Tabs>
 
 ## TypeScript config
@@ -52,4 +39,3 @@ next-international supports both the App Router and Pages Router of Next.js. The
   <Card icon={<AppIcon />} title="App Router" href="/docs/app-setup" />
   <Card icon={<PagesIcon />} title="Pages Router" href="/docs/pages-setup" />
 </Cards>
-

--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -17,7 +17,7 @@ Try it live on CodeSandbox:
 
 ## Installation
 
-<Tabs items={['pnpm', 'npm', 'yarn']}>
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
   <Tab>
     ```bash
     pnpm install next-international
@@ -31,6 +31,11 @@ Try it live on CodeSandbox:
   <Tab>
     ```bash
     yarn add next-international
+    ```
+  </Tab>
+  <Tab>
+    ```bash
+    bun add next-international
     ```
   </Tab>
 </Tabs>

--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -21,10 +21,26 @@ Try it live on CodeSandbox:
 ## Installation
 
 <Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
-  <Tab>```bash pnpm install next-international ```</Tab>
-  <Tab>```bash npm install next-international ```</Tab>
-  <Tab>```bash yarn add next-international ```</Tab>
-  <Tab>```bash bun add next-international ```</Tab>
+  <Tab>
+    ```bash
+    pnpm install next-international
+    ```
+  </Tab>
+  <Tab>
+    ```bash
+    npm install next-international
+    ```
+  </Tab>
+  <Tab>
+    ```bash
+    yarn add next-international
+    ```
+  </Tab>
+    <Tab>
+    ```bash
+    bun add next-international
+    ```
+  </Tab>
 </Tabs>
 
 ## TypeScript config


### PR DESCRIPTION
I thought it would be useful for people to also know you can install this library without any problems using bun, Vercel also supports bun installation now, so I think its handy to also have it as an option.