### PR TITLE
fix(next-international): remove unintended log in middleware

### DIFF
--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -21,7 +21,7 @@ export function createI18nMiddleware<const Locales extends readonly string[]>(co
         const response = NextResponse.rewrite(mappedUrl);
         return addLocaleToResponse(response, locale);
       } else {
-        if (strategy !== 'redirect') {
+        if (!['redirect', 'rewriteDefault'].includes(strategy)) {
           warn(`Invalid urlMappingStrategy: ${strategy}. Defaulting to redirect.`);
         }
 


### PR DESCRIPTION
This fixes the case where strategy is rewriteDefault and locale is not defaultLocale. Everything was working, but there was an accidental logs warning.