### PR TITLE
chore(docs): add `'use client'` annotation

### DIFF
--- a/docs/pages/docs/app-setup.mdx
+++ b/docs/pages/docs/app-setup.mdx
@@ -14,6 +14,7 @@ Create `locales/client.ts` and `locales/server.ts` with your locales:
 
 ```ts
 // locales/client.ts
+"use client"
 import { createI18nClient } from 'next-international/client'
 
 export const { useI18n, useScopedI18n, I18nProviderClient } = createI18nClient({


### PR DESCRIPTION
Added `"client only"` at the top of the `locales/client.ts` to prevent Next.js from yelling `'client-only' cannot be imported from a Server Component module. It should only be used from a Client Component.`