### PR TITLE
feat(next-international): export internal functions

### DIFF
--- a/packages/next-international/src/index.ts
+++ b/packages/next-international/src/index.ts
@@ -1,3 +1,5 @@
 export { createI18n } from './pages';
+export { createT } from './common/create-t';
+export { flattenLocale } from './common/flatten-locale';
 export type { ReactParamsObject } from './types';
 export type { BaseLocale, LocaleValue } from 'international-types';


### PR DESCRIPTION
Closes #229

Export `createT` and `flattenLocale`. It's not documented as it's a very niche use-case.