### PR TITLE
perf(next-international): use optional `String.prototype.split` param

### DIFF
--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -78,7 +78,7 @@ function localeFromRequest<Locales extends readonly string[]>(
 
 const defaultResolveLocaleFromRequest: NonNullable<I18nMiddlewareConfig<any>['resolveLocaleFromRequest']> = request => {
   const header = request.headers.get('Accept-Language');
-  const locale = header?.split(',')?.[0]?.split('-')?.[0];
+  const locale = header?.split(',', 1)?.[0]?.split('-', 1)?.[0];
   return locale ?? null;
 };
 

--- a/packages/next-international/src/common/create-t.ts
+++ b/packages/next-international/src/common/create-t.ts
@@ -25,7 +25,7 @@ export function createT<Locale extends BaseLocale, Scope extends Scopes<Locale> 
   const pluralKeys = new Set(
     Object.keys(content)
       .filter(key => key.includes('#'))
-      .map(key => key.split('#')[0]),
+      .map(key => key.split('#', 1)[0]),
   );
 
   const pluralRules = new Intl.PluralRules(context.locale);
@@ -62,7 +62,7 @@ export function createT<Locale extends BaseLocale, Scope extends Scopes<Locale> 
     let value = scope ? content[`${scope}.${key}`] : content[key];
 
     if (!value && isPlural) {
-      const baseKey = key.split('#')[0] as Key;
+      const baseKey = key.split('#', 1)[0] as Key;
       value = (content[`${baseKey}#other`] || key)?.toString();
     } else {
       value = (value || key)?.toString();


### PR DESCRIPTION
A optional parameter of `String.prototype.split` can be used to interrupt parsing the string after the first match.

[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split#syntax)