### PR TITLE
feat(next-international): set samesite attribute on cookies

### DIFF
--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -93,6 +93,6 @@ function noLocalePrefix(locales: readonly string[], pathname: string) {
 
 function addLocaleToResponse(response: NextResponse, locale: string) {
   response.headers.set(LOCALE_HEADER, locale);
-  response.cookies.set(LOCALE_COOKIE, locale, { sameSite: "strict"});
+  response.cookies.set(LOCALE_COOKIE, locale, { sameSite: 'strict' });
   return response;
 }

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -93,6 +93,6 @@ function noLocalePrefix(locales: readonly string[], pathname: string) {
 
 function addLocaleToResponse(response: NextResponse, locale: string) {
   response.headers.set(LOCALE_HEADER, locale);
-  response.cookies.set(LOCALE_COOKIE, locale);
+  response.cookies.set(LOCALE_COOKIE, locale, { sameSite: "strict"});
   return response;
 }


### PR DESCRIPTION
Add sameSite attribute to cookies to avoid warnings in Firefox.

Discussion: https://github.com/QuiiBz/next-international/issues/240