### PR TITLE
fix(next-international): preserve cookies in the middleware

### DIFF
--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -116,6 +116,8 @@ function addLocaleToResponse(response: NextResponse, locale: string) {
 function cloneCookies(request: NextRequest, response: NextResponse) {
   const cookies = request.cookies;
   for (const [, value] of cookies) {
-    response.cookies.set(value.name, value.value);
+    if (value.name !== LOCALE_COOKIE) {
+      response.cookies.set(value.name, value.value);
+    }
   }
 }

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -102,7 +102,7 @@ function noLocalePrefix(locales: readonly string[], pathname: string) {
 
 /**
  * Add `X-Next-Locale` header and `Next-Locale` cookie to response
- * 
+ *
  * **NOTE:** The cookie is only set if the locale is different from the one in the cookie
  */
 function addLocaleToResponse(request: NextRequest, response: NextResponse, locale: string) {

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -59,6 +59,10 @@ export function createI18nMiddleware<const Locales extends readonly string[]>(co
   };
 }
 
+/**
+ * Retrieve `Next-Locale` header from request
+ * and check if it is an handled locale.
+ */
 function localeFromRequest<Locales extends readonly string[]>(
   locales: Locales,
   request: NextRequest,
@@ -79,12 +83,19 @@ function localeFromRequest<Locales extends readonly string[]>(
   return locale;
 }
 
+/**
+ * Default implementation of the `resolveLocaleFromRequest` function for the I18nMiddlewareConfig.
+ * This function extracts the locale from the 'Accept-Language' header of the request.
+ */
 const defaultResolveLocaleFromRequest: NonNullable<I18nMiddlewareConfig<any>['resolveLocaleFromRequest']> = request => {
   const header = request.headers.get('Accept-Language');
   const locale = header?.split(',', 1)?.[0]?.split('-', 1)?.[0];
   return locale ?? null;
 };
 
+/**
+ * Returns `true` if the pathname does not start with an handled locale
+ */
 function noLocalePrefix(locales: readonly string[], pathname: string) {
   return locales.every(locale => {
     return !(pathname === `/${locale}` || pathname.startsWith(`/${locale}/`));

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -102,7 +102,8 @@ function noLocalePrefix(locales: readonly string[], pathname: string) {
 
 /**
  * Add `X-Next-Locale` header and `Next-Locale` cookie to response
- * and copy all cookies from request to response
+ * 
+ * **NOTE:** The cookie is only set if the locale is different from the one in the cookie
  */
 function addLocaleToResponse(request: NextRequest, response: NextResponse, locale: string) {
   response.headers.set(LOCALE_HEADER, locale);

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -13,8 +13,7 @@ export function createI18nMiddleware<const Locales extends readonly string[]>(co
     const locale = localeFromRequest(config.locales, request, config.resolveLocaleFromRequest) ?? config.defaultLocale;
 
     if (noLocalePrefix(config.locales, requestUrl.pathname)) {
-      const mappedUrl = requestUrl.clone();
-      mappedUrl.pathname = `/${locale}${mappedUrl.pathname}`;
+      requestUrl.pathname = `/${locale}${requestUrl.pathname}`;
 
       const strategy = config.urlMappingStrategy ?? DEFAULT_STRATEGY;
       if (strategy === 'rewrite' || (strategy === 'rewriteDefault' && locale === config.defaultLocale)) {

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -106,14 +106,9 @@ function noLocalePrefix(locales: readonly string[], pathname: string) {
  */
 function addLocaleToResponse(request: NextRequest, response: NextResponse, locale: string) {
   response.headers.set(LOCALE_HEADER, locale);
-  response.cookies.set(LOCALE_COOKIE, locale, { sameSite: 'strict' });
 
-  // Apply cookies from request to response
-  const cookies = request.cookies;
-  for (const [, value] of cookies) {
-    if (value.name !== LOCALE_COOKIE) {
-      response.cookies.set(value.name, value.value);
-    }
+  if (request.cookies.get(LOCALE_COOKIE)?.value !== locale) {
+    response.cookies.set(LOCALE_COOKIE, locale, { sameSite: 'strict' });
   }
   return response;
 }


### PR DESCRIPTION
Fixes #212 

The `response` from `NextResponse.next` and `NextResponse.redirect` doesn't contains any cookies except the `Next-Locale` set by the middleware.

At first, I wanted to clone the `headers` but this added a lot of elements that were not included in the basic Server Actions

EDIT: I've just noticed that the "Set-Cookie" header was defined for each request, which isn't great.