### PR TITLE
perf(next-international): optimize middleware

### DIFF
--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -12,7 +12,8 @@ export function createI18nMiddleware<const Locales extends readonly string[]>(co
     const locale = localeFromRequest(config.locales, request, config.resolveLocaleFromRequest) ?? config.defaultLocale;
     const nextUrl = request.nextUrl;
 
-    if (noLocalePrefix(config.locales, nextUrl.pathname)) {
+    // If the locale from the request is not an handled locale, then redirect to the same URL with the default locale
+    if (!hasHandledLocale(config.locales, nextUrl.pathname)) {
       nextUrl.pathname = `/${locale}${nextUrl.pathname}`;
 
       const strategy = config.urlMappingStrategy ?? DEFAULT_STRATEGY;
@@ -92,9 +93,9 @@ const defaultResolveLocaleFromRequest: NonNullable<I18nMiddlewareConfig<any>['re
 /**
  * Returns `true` if the pathname does not start with an handled locale
  */
-function noLocalePrefix(locales: readonly string[], pathname: string) {
-  return locales.every(locale => {
-    return !(pathname === `/${locale}` || pathname.startsWith(`/${locale}/`));
+function hasHandledLocale(locales: readonly string[], pathname: string) {
+  return locales.some(locale => {
+    return pathname === `/${locale}` || pathname.startsWith(`/${locale}/`);
   });
 }
 

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -30,7 +30,7 @@ export function createI18nMiddleware<const Locales extends readonly string[]>(co
     }
 
     let response = NextResponse.next();
-    const requestLocale = request.nextUrl.pathname.split('/')?.[1];
+    const requestLocale = request.nextUrl.pathname.split('/', 2)?.[1];
 
     if (!requestLocale || config.locales.includes(requestLocale)) {
       if (

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -13,7 +13,7 @@ export function createI18nMiddleware<const Locales extends readonly string[]>(co
     const nextUrl = request.nextUrl;
 
     // If the locale from the request is not an handled locale, then redirect to the same URL with the default locale
-    if (!hasHandledLocale(config.locales, nextUrl.pathname)) {
+    if (noLocalePrefix(config.locales, nextUrl.pathname)) {
       nextUrl.pathname = `/${locale}${nextUrl.pathname}`;
 
       const strategy = config.urlMappingStrategy ?? DEFAULT_STRATEGY;
@@ -93,9 +93,9 @@ const defaultResolveLocaleFromRequest: NonNullable<I18nMiddlewareConfig<any>['re
 /**
  * Returns `true` if the pathname does not start with an handled locale
  */
-function hasHandledLocale(locales: readonly string[], pathname: string) {
-  return locales.some(locale => {
-    return pathname === `/${locale}` || pathname.startsWith(`/${locale}/`);
+function noLocalePrefix(locales: readonly string[], pathname: string) {
+  return locales.every(locale => {
+    return !(pathname === `/${locale}` || pathname.startsWith(`/${locale}/`));
   });
 }
 

--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -68,14 +68,10 @@ function localeFromRequest<Locales extends readonly string[]>(
     I18nMiddlewareConfig<Locales>['resolveLocaleFromRequest']
   > = defaultResolveLocaleFromRequest,
 ) {
-  let locale = request.cookies.get(LOCALE_COOKIE)?.value ?? null;
-
-  if (!locale) {
-    locale = resolveLocaleFromRequest(request);
-  }
+  const locale = request.cookies.get(LOCALE_COOKIE)?.value ?? resolveLocaleFromRequest(request);
 
   if (!locale || !locales.includes(locale)) {
-    locale = null;
+    return null;
   }
 
   return locale;


### PR DESCRIPTION
- Like the following PR https://github.com/QuiiBz/next-international/pull/238, when the URL are becoming long like https://github.com/QuiiBz/next-international/issues/..., there will be no loss of performance.
- I've also simplified the condition and added some comments on the `redirect` part but I'm not sure it's easy to read and understand this part so don't hesitate to give your opinion.
- In the `localeFromRequest` function, there were several assignments that weren't necessary, so I merged them.
- I removed the `clone()` call (from `nextUrl`) because it creates a new instance and it seems to be no longer documented on the doc, only on [error messages](https://nextjs.org/docs/messages/middleware-relative-urls)