### PR TITLE
fix: execute function in I18nProviderWrapper instead of I18nProvider

### DIFF
--- a/examples/next-app/locales/client.ts
+++ b/examples/next-app/locales/client.ts
@@ -4,8 +4,14 @@ import { createI18nClient } from 'next-international/client';
 export const { useI18n, useScopedI18n, I18nProviderClient, useChangeLocale, defineLocale, useCurrentLocale } =
   createI18nClient(
     {
-      en: () => import('./en'),
-      fr: () => import('./fr'),
+      en: async () => {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        return import('./en');
+      },
+      fr: async () => {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        return import('./fr');
+      },
     },
     {
       // Uncomment to set base path

--- a/examples/next-app/locales/client.ts
+++ b/examples/next-app/locales/client.ts
@@ -4,14 +4,8 @@ import { createI18nClient } from 'next-international/client';
 export const { useI18n, useScopedI18n, I18nProviderClient, useChangeLocale, defineLocale, useCurrentLocale } =
   createI18nClient(
     {
-      en: async () => {
-        await new Promise(resolve => setTimeout(resolve, 100));
-        return import('./en');
-      },
-      fr: async () => {
-        await new Promise(resolve => setTimeout(resolve, 100));
-        return import('./fr');
-      },
+      en: () => import('./en'),
+      fr: () => import('./fr'),
     },
     {
       // Uncomment to set base path

--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -11,9 +11,8 @@ type I18nProviderProps = Omit<I18nProviderWrapperProps, 'fallback'>;
 type I18nProviderWrapperProps = {
   locale: string;
   fallback?: ReactNode;
-  children: ReactNode;
-
   importLocale: Promise<Record<string, unknown>>;
+  children: ReactNode;
 };
 
 export const localesCache = new Map<string, Record<string, unknown>>();
@@ -25,9 +24,11 @@ export function createI18nProviderClient<Locale extends BaseLocale>(
 ) {
   function I18nProvider({ locale, importLocale, children }: I18nProviderProps) {
     const clientLocale = (localesCache.get(locale) ?? use(importLocale).default) as Record<string, unknown>;
+
     if (!localesCache.has(locale)) {
       localesCache.set(locale, clientLocale);
     }
+
     const value = useMemo(
       () => ({
         localeContent: flattenLocale<Locale>(clientLocale),
@@ -42,6 +43,7 @@ export function createI18nProviderClient<Locale extends BaseLocale>(
 
   return function I18nProviderWrapper({ locale, fallback, children }: I18nProviderWrapperProps) {
     const importFnLocale = locales[locale as keyof typeof locales];
+
     if (!importFnLocale) {
       error(`The locale '${locale}' is not supported. Defined locales are: [${Object.keys(locales).join(', ')}].`);
       notFound();

--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -1,5 +1,5 @@
-import { notFound } from 'next/navigation';
 import type { BaseLocale, ImportedLocales } from 'international-types';
+import { notFound } from 'next/navigation';
 import type { Context, ReactNode } from 'react';
 import React, { Suspense, use, useMemo } from 'react';
 import { flattenLocale } from '../../common/flatten-locale';
@@ -16,13 +16,18 @@ type I18nProviderWrapperProps = {
   importLocale: Promise<Record<string, unknown>>;
 };
 
+export const localesCache = new Map<string, Record<string, unknown>>();
+
 export function createI18nProviderClient<Locale extends BaseLocale>(
   I18nClientContext: Context<LocaleContext<Locale> | null>,
   locales: ImportedLocales,
   fallbackLocale?: Record<string, unknown>,
 ) {
   function I18nProvider({ locale, importLocale, children }: I18nProviderProps) {
-    const clientLocale = use(importLocale).default as Record<string, unknown>;
+    const clientLocale = (localesCache.get(locale) ?? use(importLocale).default) as Record<string, unknown>;
+    if (!localesCache.has(locale)) {
+      localesCache.set(locale, clientLocale);
+    }
     const value = useMemo(
       () => ({
         localeContent: flattenLocale<Locale>(clientLocale),

--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -16,8 +16,6 @@ type I18nProviderWrapperProps = {
   importLocale: Promise<Record<string, unknown>>;
 };
 
-export const localesCache = new Map<string, Record<string, unknown>>();
-
 export function createI18nProviderClient<Locale extends BaseLocale>(
   I18nClientContext: Context<LocaleContext<Locale> | null>,
   locales: ImportedLocales,
@@ -25,7 +23,6 @@ export function createI18nProviderClient<Locale extends BaseLocale>(
 ) {
   function I18nProvider({ locale, importLocale, children }: I18nProviderProps) {
     const clientLocale = use(importLocale).default as Record<string, unknown>;
-    localesCache.set(locale, clientLocale);
     const value = useMemo(
       () => ({
         localeContent: flattenLocale<Locale>(clientLocale),

--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -1,7 +1,6 @@
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import type { I18nChangeLocaleConfig, I18nClientConfig } from '../../types';
 import type { ImportedLocales } from 'international-types';
-import { localesCache } from './create-i18n-provider-client';
 
 export function createUseChangeLocale<LocalesKeys>(
   useCurrentLocale: () => LocalesKeys,
@@ -30,9 +29,7 @@ export function createUseChangeLocale<LocalesKeys>(
     }
 
     return function changeLocale(newLocale: LocalesKeys) {
-      locales[newLocale as keyof typeof locales]().then(module => {
-        localesCache.set(newLocale as string, module.default);
-
+      locales[newLocale as keyof typeof locales]().then(() => {
         push(`/${newLocale}${pathWithoutLocale}${finalSearchParams}`);
         refresh();
       });

--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -1,3 +1,4 @@
+import { warn } from '../../helpers/log';
 import type { ImportedLocales } from 'international-types';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import type { I18nChangeLocaleConfig, I18nClientConfig } from '../../types';
@@ -30,7 +31,13 @@ export function createUseChangeLocale<LocalesKeys>(
     }
 
     return function changeLocale(newLocale: LocalesKeys) {
-      locales[newLocale as keyof typeof locales]().then(module => {
+      const importFnLocale = locales[newLocale as keyof typeof locales];
+      if (!importFnLocale) {
+        warn(`The locale '${newLocale}' is not supported.`);
+        return;
+      }
+
+      importFnLocale().then(module => {
         localesCache.set(newLocale as string, module.default);
         push(`/${newLocale}${pathWithoutLocale}${finalSearchParams}`);
         refresh();

--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -32,13 +32,15 @@ export function createUseChangeLocale<LocalesKeys>(
 
     return function changeLocale(newLocale: LocalesKeys) {
       const importFnLocale = locales[newLocale as keyof typeof locales];
+
       if (!importFnLocale) {
-        warn(`The locale '${newLocale}' is not supported.`);
+        warn(`The locale '${newLocale}' is not supported. Defined locales are: [${Object.keys(locales).join(', ')}].`);
         return;
       }
 
       importFnLocale().then(module => {
         localesCache.set(newLocale as string, module.default);
+
         push(`/${newLocale}${pathWithoutLocale}${finalSearchParams}`);
         refresh();
       });

--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -1,6 +1,7 @@
-import { useRouter, usePathname, useSearchParams } from 'next/navigation';
-import type { I18nChangeLocaleConfig, I18nClientConfig } from '../../types';
 import type { ImportedLocales } from 'international-types';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import type { I18nChangeLocaleConfig, I18nClientConfig } from '../../types';
+import { localesCache } from './create-i18n-provider-client';
 
 export function createUseChangeLocale<LocalesKeys>(
   useCurrentLocale: () => LocalesKeys,
@@ -29,7 +30,8 @@ export function createUseChangeLocale<LocalesKeys>(
     }
 
     return function changeLocale(newLocale: LocalesKeys) {
-      locales[newLocale as keyof typeof locales]().then(() => {
+      locales[newLocale as keyof typeof locales]().then(module => {
+        localesCache.set(newLocale as string, module.default);
         push(`/${newLocale}${pathWithoutLocale}${finalSearchParams}`);
         refresh();
       });


### PR DESCRIPTION
Closes #290 

With this fix, I wasn't able to reproduce the crash.

## What is this PR ?
It moves the call of `() => import("./en")` from `I18nProvider` to `I18nProviderWrapper`.

I changed this because according to the React documentation of `use` hook (https://react.dev/reference/react/use#streaming-data-from-server-to-client), the promise is executed and passed as a prop from the parent but awaited in the child.