### PR TITLE
feat: avoid refresh if new locale is already the current locale

### DIFF
--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -31,10 +31,7 @@ export function createUseChangeLocale<LocalesKeys>(
     }
 
     return function changeLocale(newLocale: LocalesKeys) {
-      if (newLocale === currentLocale) {
-        warn(`The locale '${newLocale}' is already set`);
-        return;
-      }
+      if (newLocale === currentLocale) return;
 
       const importFnLocale = locales[newLocale as keyof typeof locales];
 

--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -32,7 +32,7 @@ export function createUseChangeLocale<LocalesKeys>(
 
     return function changeLocale(newLocale: LocalesKeys) {
       if (newLocale === currentLocale) {
-        warn(`The locale '${newLocale}' is already set. Defined locales are: [${Object.keys(locales).join(', ')}].`);
+        warn(`The locale '${newLocale}' is already set`);
         return;
       }
 

--- a/packages/next-international/src/app/client/create-use-change-locale.ts
+++ b/packages/next-international/src/app/client/create-use-change-locale.ts
@@ -31,6 +31,11 @@ export function createUseChangeLocale<LocalesKeys>(
     }
 
     return function changeLocale(newLocale: LocalesKeys) {
+      if (newLocale === currentLocale) {
+        warn(`The locale '${newLocale}' is already set. Defined locales are: [${Object.keys(locales).join(', ')}].`);
+        return;
+      }
+
       const importFnLocale = locales[newLocale as keyof typeof locales];
 
       if (!importFnLocale) {


### PR DESCRIPTION
So, currently, if we set the locale that is already set, it rerenders the page. To avoid this, I think an early locale check would be helpful.

Here is the record:
https://github.com/QuiiBz/next-international/assets/63459189/fa926b15-97dc-4ecb-b41e-9aac8f21cca5

