### PR TITLE
perf(next-international) improve caching and calls

### DIFF
--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -24,11 +24,7 @@ export function createI18nProviderClient<Locale extends BaseLocale>(
   fallbackLocale?: Record<string, unknown>,
 ) {
   function I18nProvider({ locale, importLocale, children }: I18nProviderProps) {
-    const clientLocale = (localesCache.get(locale) ?? use(importLocale).default) as Record<string, unknown>;
-
-    if (!localesCache.has(locale)) {
-      localesCache.set(locale, clientLocale);
-    }
+    const clientLocale = (localesCache.get(locale) ?? localesCache.set(locale, use(importLocale).default)) as Record<string, unknown>;
 
     const value = useMemo(
       () => ({

--- a/packages/next-international/src/app/client/create-i18n-provider-client.tsx
+++ b/packages/next-international/src/app/client/create-i18n-provider-client.tsx
@@ -24,7 +24,10 @@ export function createI18nProviderClient<Locale extends BaseLocale>(
   fallbackLocale?: Record<string, unknown>,
 ) {
   function I18nProvider({ locale, importLocale, children }: I18nProviderProps) {
-    const clientLocale = (localesCache.get(locale) ?? localesCache.set(locale, use(importLocale).default)) as Record<string, unknown>;
+    const clientLocale = (localesCache.get(locale) ?? localesCache.set(locale, use(importLocale).default)) as Record<
+      string,
+      unknown
+    >;
 
     const value = useMemo(
       () => ({

--- a/packages/next-international/src/common/create-t.ts
+++ b/packages/next-international/src/common/create-t.ts
@@ -26,13 +26,15 @@ export function createT<Locale extends BaseLocale, Scope extends Scopes<Locale> 
       : Object.assign(fallbackLocale ?? {}, localeContent);
 
   function getCachedPluralKeys() {
-    if (!pluralKeysCache) {
-      pluralKeysCache = new Set(
-        Object.keys(content)
-          .filter(key => key.includes('#'))
-          .map(key => key.split('#', 1)[0]),
-      );
+    if (pluralKeysCache) {
+      return pluralKeysCache;
     }
+
+    pluralKeysCache = new Set(
+      Object.keys(content)
+        .filter(key => key.includes('#'))
+        .map(key => key.split('#', 1)[0]),
+    );
     return pluralKeysCache;
   }
 

--- a/packages/next-international/src/common/create-t.ts
+++ b/packages/next-international/src/common/create-t.ts
@@ -11,7 +11,7 @@ import type { ReactNode } from 'react';
 import { cloneElement, isValidElement } from 'react';
 import type { LocaleContext, LocaleMap, ReactParamsObject } from '../types';
 
-let pluralKeysCache = new Set<string>();
+let pluralKeysCache: Set<string> | undefined = undefined;
 
 export function createT<Locale extends BaseLocale, Scope extends Scopes<Locale> | undefined>(
   context: LocaleContext<Locale>,

--- a/packages/next-international/src/common/create-t.ts
+++ b/packages/next-international/src/common/create-t.ts
@@ -11,6 +11,8 @@ import type { ReactNode } from 'react';
 import { cloneElement, isValidElement } from 'react';
 import type { LocaleContext, LocaleMap, ReactParamsObject } from '../types';
 
+let pluralKeysCache = new Set<string>();
+
 export function createT<Locale extends BaseLocale, Scope extends Scopes<Locale> | undefined>(
   context: LocaleContext<Locale>,
   scope: Scope | undefined,
@@ -23,12 +25,18 @@ export function createT<Locale extends BaseLocale, Scope extends Scopes<Locale> 
       ? fallbackLocale
       : Object.assign(fallbackLocale ?? {}, localeContent);
 
-  const pluralKeys = new Set(
-    Object.keys(content)
-      .filter(key => key.includes('#'))
-      .map(key => key.split('#', 1)[0]),
-  );
+  function getCachedPluralKeys() {
+    if (!pluralKeysCache) {
+      pluralKeysCache = new Set(
+        Object.keys(content)
+          .filter(key => key.includes('#'))
+          .map(key => key.split('#', 1)[0]),
+      );
+    }
+    return pluralKeysCache;
+  }
 
+  const pluralKeys = getCachedPluralKeys();
   const pluralRules = new Intl.PluralRules(context.locale);
 
   function getPluralKey(count: number) {


### PR DESCRIPTION
The following code can become heavy with multiple keys and usage of scopes:
https://github.com/QuiiBz/next-international/blob/7887342c60f5cceaa8ed0456a8ef068db4b87909/packages/next-international/src/common/create-t.ts#L26-L30
I think we can store all the plural keys after the first iteration so that we don't need to iterate over the keys anymore

On the following code : 
https://github.com/QuiiBz/next-international/blob/7887342c60f5cceaa8ed0456a8ef068db4b87909/packages/next-international/src/app/client/create-i18n-provider-client.tsx#L27-L31

The [`Map.prototype.set`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set#return_value) is returning the Map so we don't to check if the `localesCache` has `locale` as a key because we already have this information with the `localesCache.get`