### PR TITLE
fix(next-international): `fallbackLocale` type for pages router

### DIFF
--- a/packages/next-international/src/pages/create-i18n-provider.tsx
+++ b/packages/next-international/src/pages/create-i18n-provider.tsx
@@ -9,7 +9,7 @@ import type { LocaleContext } from '../types';
 type I18nProviderProps<Locale extends BaseLocale> = {
   locale: Locale;
   fallback?: ReactElement | null;
-  fallbackLocale?: BaseLocale;
+  fallbackLocale?: Record<string, unknown>;
   children: ReactNode;
 };
 


### PR DESCRIPTION
Closes https://github.com/QuiiBz/next-international/issues/344

The `fallbackLocale` prop from `I18nProvider` when using the Pages Router should accept nested locales.