### PR TITLE
feat(v2): `useLocale`, `useChangeLocale` support

### DIFF
--- a/examples/app/app/[locale]/client-component.tsx
+++ b/examples/app/app/[locale]/client-component.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import React from 'react';
-import { useI18n, useScopedI18n } from '@/locales';
+import { useChangeLocale, useI18n, useLocale, useScopedI18n } from '@/locales';
 
 export function ClientComponent() {
   const t = useI18n();
   const scopedT = useScopedI18n('hello');
+  const locale = useLocale();
+  const changeLocale = useChangeLocale();
 
   return (
     <div>
@@ -21,6 +23,23 @@ export function ClientComponent() {
           name: 'John',
         })}
       </p>
+      <p>Current locale: {locale}</p>
+      <button
+        type="button"
+        onClick={() => {
+          changeLocale('en');
+        }}
+      >
+        EN
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          changeLocale('fr');
+        }}
+      >
+        FR
+      </button>
     </div>
   );
 }

--- a/examples/app/app/[locale]/layout.tsx
+++ b/examples/app/app/[locale]/layout.tsx
@@ -8,8 +8,10 @@ export function generateStaticParams() {
 
 export default function RootLayout({
   children,
+  params: { locale },
 }: Readonly<{
   children: React.ReactNode;
+  params: { locale: string };
 }>) {
-  return <I18nProvider>{children}</I18nProvider>;
+  return <I18nProvider locale={locale}>{children}</I18nProvider>;
 }

--- a/examples/app/app/[locale]/page.tsx
+++ b/examples/app/app/[locale]/page.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { useI18n, useScopedI18n } from '@/locales';
+import { useI18n, useLocale, useScopedI18n } from '@/locales';
 import { ClientComponent } from './client-component';
 
 export default function Home() {
   const t = useI18n();
   const scopedT = useScopedI18n('hello');
+  const locale = useLocale();
 
   return (
     <div>
@@ -20,6 +21,8 @@ export default function Home() {
           name: 'John',
         })}
       </p>
+      <p>Current locale: {locale}</p>
+      <hr />
       <ClientComponent />
     </div>
   );

--- a/examples/app/locales/index.ts
+++ b/examples/app/locales/index.ts
@@ -1,6 +1,7 @@
 import { createI18n } from 'next-international/app';
 
-export const { useI18n, useScopedI18n, I18nProvider, generateI18nStaticParams } = createI18n({
-  en: () => import('./en'),
-  fr: () => import('./fr'),
-});
+export const { useI18n, useScopedI18n, I18nProvider, generateI18nStaticParams, useLocale, useChangeLocale } =
+  createI18n({
+    en: () => import('./en'),
+    fr: () => import('./fr'),
+  });

--- a/packages/next-international/src/app/app/provider.tsx
+++ b/packages/next-international/src/app/app/provider.tsx
@@ -4,7 +4,7 @@ import type { LocaleType } from 'international-types';
 import type { I18nProvider } from './types';
 
 export const createI18nProvider = <Locale extends LocaleType>() => {
-  const Provider: I18nProvider<Locale> = ({ children }) => {
+  const Provider: I18nProvider<Locale> = ({ locale, children }) => {
     return children;
   };
 

--- a/packages/next-international/src/app/app/server.ts
+++ b/packages/next-international/src/app/app/server.ts
@@ -1,21 +1,47 @@
 import type { GetLocale, LocaleType, LocalesObject } from 'international-types';
-import type { CreateI18n, GenerateI18nStaticParams, I18nConfig, UseI18n, UseScopedI18n } from './types';
+import type {
+  CreateI18n,
+  GenerateI18nStaticParams,
+  I18nConfig,
+  UseChangeLocale,
+  UseI18n,
+  UseLocale,
+  UseScopedI18n,
+} from './types';
 import { createI18nProvider } from './provider';
 import { SEGMENT_NAME } from './constants';
+// @ts-expect-error - no types
+import { cache } from 'react';
+import { staticGenerationAsyncStorage } from 'next/dist/client/components/static-generation-async-storage.external';
+
+const useLocaleCache = cache(() => {
+  const store = staticGenerationAsyncStorage.getStore();
+  const url = store?.urlPathname;
+
+  if (typeof url !== 'string') {
+    throw new Error('Invariant: urlPathname is not a string: ' + JSON.stringify(store, null, 2));
+  }
+
+  return url.split('/')[1].split('?')[0];
+});
 
 export function createI18n<Locales extends LocalesObject, Locale extends LocaleType = GetLocale<Locales>>(
   locales: Locales,
   config: I18nConfig = {},
-): CreateI18n<Locale> {
+): CreateI18n<Locales, Locale> {
   const useI18n: UseI18n<Locale> = () => {
+    const locale = useLocaleCache();
+
     return (key, ...params) => {
-      return 'server';
+      return 'server: ' + locale;
     };
   };
 
   const useScopedI18n: UseScopedI18n<Locale> = scope => {
+    const locale = useLocaleCache();
+
     return (key, ...params) => {
-      return 'server';
+      return 'server: ' + locale;
     };
   };
 
@@ -25,10 +51,22 @@ export function createI18n<Locales extends LocalesObject, Locale extends LocaleT
     return Object.keys(locales).map(locale => ({ [config.segmentName ?? SEGMENT_NAME]: locale }));
   };
 
+  const useLocale: UseLocale<Locales> = () => {
+    return useLocaleCache();
+  };
+
+  const useChangeLocale: UseChangeLocale<Locales> = () => {
+    return () => {
+      throw new Error('Invariant: useChangeLocale only works in Client Components');
+    };
+  };
+
   return {
     useI18n,
     useScopedI18n,
     I18nProvider,
     generateI18nStaticParams,
+    useLocale,
+    useChangeLocale,
   };
 }

--- a/packages/next-international/src/app/app/types.ts
+++ b/packages/next-international/src/app/app/types.ts
@@ -1,4 +1,4 @@
-import type { Keys, LocaleType, Params, Scopes } from 'international-types';
+import type { Keys, LocaleType, LocalesObject, Params, Scopes } from 'international-types';
 import type { ReactNode } from 'react';
 
 export type UseI18n<Locale extends LocaleType> = () => <Key extends Keys<Locale>>(
@@ -11,6 +11,7 @@ export type UseScopedI18n<Locale extends LocaleType> = <Scope extends Scopes<Loc
 ) => <Key extends Keys<Locale, Scope>>(key: Key, ...params: Params<Locale, Scope, Key>) => string;
 
 export type I18nProviderProps<Locale extends LocaleType> = {
+  locale: string;
   children: ReactNode;
 };
 
@@ -18,11 +19,17 @@ export type I18nProvider<Locale extends LocaleType> = (props: I18nProviderProps<
 
 export type GenerateI18nStaticParams = () => Array<Record<string, string>>;
 
-export type CreateI18n<Locale extends LocaleType> = {
+export type UseLocale<Locales extends LocalesObject> = () => keyof Locales;
+
+export type UseChangeLocale<Locales extends LocalesObject> = () => (locale: keyof Locales) => void;
+
+export type CreateI18n<Locales extends LocalesObject, Locale extends LocaleType> = {
   useI18n: UseI18n<Locale>;
   useScopedI18n: UseScopedI18n<Locale>;
   I18nProvider: I18nProvider<Locale>;
   generateI18nStaticParams: GenerateI18nStaticParams;
+  useLocale: UseLocale<Locales>;
+  useChangeLocale: UseChangeLocale<Locales>;
 };
 
 export type I18nConfig = {


### PR DESCRIPTION
### Rename locale helpers

The locale helper functions have been renamed to be more simple:

- `useCurrentLocale()` -> `useLocale()`
- `getCurrentLocale()` -> `useLocale()`
- No update: `useChangeLocale()`