### PR TITLE
Fix: Localization Settings reset with OAuth Flows

### DIFF
--- a/packages/next-international/src/app/middleware/index.ts
+++ b/packages/next-international/src/app/middleware/index.ts
@@ -108,7 +108,7 @@ function addLocaleToResponse(request: NextRequest, response: NextResponse, local
   response.headers.set(LOCALE_HEADER, locale);
 
   if (request.cookies.get(LOCALE_COOKIE)?.value !== locale) {
-    response.cookies.set(LOCALE_COOKIE, locale, { sameSite: 'strict' });
+    response.cookies.set(LOCALE_COOKIE, locale, { sameSite: 'lax' });
   }
   return response;
 }


### PR DESCRIPTION
Oauth processes were broken with `sameSite: 'strict'` cookie settings. Meaning, whenever a user signed into my site using oauth, it reset the localization setting.

E.g. when I implemented Google OAuth in my app, the Next.js middleware has no cookies set, as the browser doesn't send the cookie if it's coming from an OAuth source (not same site). Then the library reset the cookie from the locale settings, so the user setting got lost.

Cookie should be safe to set to 'lax' as it's not security relevant.